### PR TITLE
Fixed link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Core Plot is an open source project hosted on [GitHub](https://github.com/core-p
 
    * [core-plot](https://github.com/core-plot/core-plot): This is main code repository with the framework and all examples. This is where you will find the release packages, wiki pages, and issue tracker.
 
-   * [core-plot.github.io](https://github.com/core-plot/core-plot.github.io): This is the HTML API documentation. You can view the pages online at [http://core-plot.github.io]().
+   * [core-plot.github.io](https://github.com/core-plot/core-plot.github.io): This is the HTML API documentation. You can view the pages online at [http://core-plot.github.io](http://core-plot.github.io).
 
 ## Coding Standards
 Everyone has a their own preferred coding style, and no one way can be considered right. Nonetheless, in a project like Core Plot, with many developers contributing, it is worthwhile defining a set of basic coding standards to prevent a mishmash of different styles which can become frustrating when navigating the code base. See the file [Coding Style.markdown](https://github.com/core-plot/core-plot/blob/master/documentation/Coding%20Style.markdown) found in the [documentation](https://github.com/core-plot/core-plot/tree/master/documentation)  directory of the project source for specific guidelines.


### PR DESCRIPTION
`[text]()` is interpreted as a relative path.
