### PR TITLE
Speed up Symbol drawing

### DIFF
--- a/framework/Source/CPTPlotSymbol.m
+++ b/framework/Source/CPTPlotSymbol.m
@@ -578,6 +578,11 @@
             CGContextTranslateCTM(context, center.x + ( symbolAnchor.x - CPTFloat(0.5) ) * symbolSize.width, center.y + ( symbolAnchor.y - CPTFloat(0.5) ) * symbolSize.height);
             CGContextScaleCTM(context, scale, scale);
             [self.shadow setShadowInContext:context];
+            
+            // redraw only symbol rectangle
+            CGRect symbolRect = CGRectMake(symbolAnchor.x - symbolSize.width, symbolAnchor.y - symbolSize.height, symbolSize.width * 2, symbolSize.height * 2);
+            CGContextClipToRect(context, symbolRect);
+            
             CGContextBeginTransparencyLayer(context, NULL);
 
             if ( theFill ) {


### PR DESCRIPTION
When I call reloadDataInIndexRange on two points to change Symbols on tap, library hang main thread for about 500 ms. Here is backtrace from time profiler:

![zrzut ekranu 2014-03-17 o 15 16 51](https://f.cloud.github.com/assets/512353/2436775/c138f624-addf-11e3-85f4-58825773c901.png)

To fix it I use simple 2 lines of code, which redraw only Symbol rectangle.
