### PR TITLE
allow the user to cancel any animations due to momentum

### DIFF
--- a/framework/Source/CPTXYPlotSpace.h
+++ b/framework/Source/CPTXYPlotSpace.h
@@ -22,4 +22,6 @@
 @property (nonatomic, readwrite) CGFloat bounceAcceleration;
 @property (nonatomic, readwrite) CGFloat minimumDisplacementToDrag;
 
+- (void)cancelAnimations;
+
 @end

--- a/framework/Source/CPTXYPlotSpace.m
+++ b/framework/Source/CPTXYPlotSpace.m
@@ -1579,6 +1579,17 @@ CGFloat firstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
 }
 #endif
 
+/**
+ *  @brief Reset the dragging state and cancel any active animations.
+ **/
+- (void)cancelAnimations
+{
+    self.isDragging = NO;
+    for ( CPTAnimationOperation *op in self.animations ) {
+        [[CPTAnimation sharedInstance] removeAnimationOperation:op];
+    }
+}
+
 /// @}
 
 #pragma mark -


### PR DESCRIPTION
If the user code makes changes to the plot while momentum is still
occurring things are not happy. I don't remember the details right now
but prior to modifying the plot I invoke cancelAnimations and the race
condition no longer occurs.
