### PR TITLE
Chart interactions break UICollectionViewDelegate delegations

### DIFF
--- a/framework/iPhoneOnly/CPTGraphHostingView.m
+++ b/framework/iPhoneOnly/CPTGraphHostingView.m
@@ -131,6 +131,7 @@
 
 -(void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {
+    [super touchesBegan:touches withEvent:event];
     // Ignore pinch or other multitouch gestures
     if ( [[event allTouches] count] > 1 ) {
         return;
@@ -158,6 +159,7 @@
 
 -(void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
 {
+    [super touchesMoved: touches withEvent:event];
     CPTGraph *theHostedGraph = self.hostedGraph;
 
     theHostedGraph.frame = self.bounds;
@@ -180,6 +182,7 @@
 
 -(void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
 {
+    [super touchesEnded:touches withEvent:event];
     CPTGraph *theHostedGraph = self.hostedGraph;
 
     theHostedGraph.frame = self.bounds;
@@ -202,6 +205,7 @@
 
 -(void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
+    [super touchesCancelled:touches withEvent:event];
     BOOL handled = [self.hostedGraph pointingDeviceCancelledEvent:event];
 
     if ( !handled ) {


### PR DESCRIPTION
Discovered in iOS 8.1.3, but reproducible in iOS 7.1 simulator.

Because `CPTGraphHostingView` overrides `UIView` functions and doesn't call super, it appears to upset collection views.  I assume the same applies to UITableView.

To reproduce:

1. Create a collection view with 1 section and two cells, and set the `UICollectionViewDelegate` and `UICollectionViewDatasource` delegates to be the view controller.  Make sure `userInteractionEnabled` is set to `YES` on the collection view.

    a. Draw a core-plot chart in cell 1.  In otherwords in the `cellForItemAtIndexPath:(NSIndexPath *)indexPath` function where indexPath = section 0, item 0, add a coreplot chart to this cell.
    b. Cell 2 has nothing in it (indexPath = section 0, item 1)

2. Put the following two functions in your collection view:

  ```objective-c
  -(BOOL)collectionView:(UICollectionView *)collectionView shouldSelectItemAtIndexPath:(NSIndexPath *)indexPath{
      NSLog(@"'shouldSelectItem' called on item %d", indexPath.item);
      return YES;
  }
  - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
      NSLog(@"'didSelectItem' called on item %d", indexPath.item);
  }
  ```
3. Select the second cell.  Observe the logs, and notice the delegations are called appropriately when the cell is selected.
4. Now select a data segment in the chart to kickoff the coreplot touch events.  
5. Now select a collection view cell.  Notice that the collection view delegations have stopped being called, and interaction with the collection view cells has effectively ceased.
