### PR TITLE
Added showBarBorder property to CPTTradingRangePlot

### DIFF
--- a/framework/Source/CPTTradingRangePlot.h
+++ b/framework/Source/CPTTradingRangePlot.h
@@ -238,6 +238,7 @@ typedef NS_ENUM (NSInteger, CPTTradingRangePlotField) {
 @property (nonatomic, readwrite, assign) CGFloat barWidth;    // In view coordinates
 @property (nonatomic, readwrite, assign) CGFloat stickLength; // In view coordinates
 @property (nonatomic, readwrite, assign) CGFloat barCornerRadius;
+@property (nonatomic, readwrite, assign) BOOL showBarBorder;
 /// @}
 
 /// @name Drawing


### PR DESCRIPTION
I created a new property named *showBarBorder* on *CPTTradingRangePlot* (candlestick chart)
With this property, users can choose wether the candlestick body's border is drawn or not

**showBarBorder=YES** (default)

![captura de pantalla 2015-02-13 a la s 16 12 06](https://cloud.githubusercontent.com/assets/659832/6189493/5700a7f8-b39b-11e4-9a86-e1874763435b.png)

**showBarBorder=NO**

![captura de pantalla 2015-02-13 a la s 16 11 20](https://cloud.githubusercontent.com/assets/659832/6189497/5d4c7da8-b39b-11e4-85de-cea29d023d56.png)
  
Much better, isn't it? :smirk: