### PR TITLE
Fixed compiler warnings (XCode 6.3)

### DIFF
--- a/framework/iPhoneOnly/CPTTextStylePlatformSpecific.m
+++ b/framework/iPhoneOnly/CPTTextStylePlatformSpecific.m
@@ -39,7 +39,7 @@
     CPTMutableTextStyle *newStyle = [CPTMutableTextStyle textStyle];
 
     // Font
-    BOOL hasFontAttributeName = (&NSFontAttributeName != NULL);
+    BOOL hasFontAttributeName = (NSFontAttributeName != nil);
 
     if ( hasFontAttributeName ) {
         UIFont *styleFont = attributes[NSFontAttributeName];
@@ -51,7 +51,7 @@
     }
 
     // Color
-    BOOL hasColorAttributeName = (&NSForegroundColorAttributeName != NULL);
+    BOOL hasColorAttributeName = (NSForegroundColorAttributeName != nil);
 
     if ( hasColorAttributeName ) {
         UIColor *styleColor = attributes[NSForegroundColorAttributeName];
@@ -61,7 +61,7 @@
     }
 
     // Text alignment and line break mode
-    BOOL hasParagraphAttributeName = (&NSParagraphStyleAttributeName != NULL);
+    BOOL hasParagraphAttributeName = (NSParagraphStyleAttributeName != nil);
 
     if ( hasParagraphAttributeName ) {
         NSParagraphStyle *paragraphStyle = attributes[NSParagraphStyleAttributeName];
@@ -84,7 +84,7 @@
     NSMutableDictionary *myAttributes = [NSMutableDictionary dictionary];
 
     // Font
-    BOOL hasFontAttributeName = (&NSFontAttributeName != NULL);
+    BOOL hasFontAttributeName = (NSFontAttributeName != nil);
 
     if ( hasFontAttributeName ) {
         UIFont *styleFont = [UIFont fontWithName:self.fontName size:self.fontSize];
@@ -96,7 +96,7 @@
     }
 
     // Color
-    BOOL hasColorAttributeName = (&NSForegroundColorAttributeName != NULL);
+    BOOL hasColorAttributeName = (NSForegroundColorAttributeName != nil);
 
     if ( hasColorAttributeName ) {
         UIColor *styleColor = self.color.uiColor;
@@ -108,7 +108,7 @@
     }
 
     // Text alignment and line break mode
-    BOOL hasParagraphAttributeName = (&NSParagraphStyleAttributeName != NULL);
+    BOOL hasParagraphAttributeName = (NSParagraphStyleAttributeName != nil);
 
     if ( hasParagraphAttributeName ) {
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
@@ -137,7 +137,7 @@
     CPTMutableTextStyle *newStyle = [CPTMutableTextStyle textStyle];
 
     // Font
-    BOOL hasFontAttributeName = (&NSFontAttributeName != NULL);
+    BOOL hasFontAttributeName = (NSFontAttributeName != nil);
 
     if ( hasFontAttributeName ) {
         UIFont *styleFont = attributes[NSFontAttributeName];
@@ -149,7 +149,7 @@
     }
 
     // Color
-    BOOL hasColorAttributeName = (&NSForegroundColorAttributeName != NULL);
+    BOOL hasColorAttributeName = (NSForegroundColorAttributeName != nil);
 
     if ( hasColorAttributeName ) {
         UIColor *styleColor = attributes[NSForegroundColorAttributeName];
@@ -160,7 +160,7 @@
     }
 
     // Text alignment and line break mode
-    BOOL hasParagraphAttributeName = (&NSParagraphStyleAttributeName != NULL);
+    BOOL hasParagraphAttributeName = (NSParagraphStyleAttributeName != nil);
 
     if ( hasParagraphAttributeName ) {
         NSParagraphStyle *paragraphStyle = attributes[NSParagraphStyleAttributeName];


### PR DESCRIPTION
Fixed warning: Comparison of address of 'myObject' not equal to a null pointer is always true.

See the image for an example warning:
![screenshot 2015-04-23 16 23 40](https://cloud.githubusercontent.com/assets/527427/7297977/2f75aae2-e9d5-11e4-9d40-6e241ae1e437.png)