### PR TITLE
Fixed always true in CPTCreateRoundedRectPath

### DIFF
--- a/framework/Source/CPTPathExtensions.m
+++ b/framework/Source/CPTPathExtensions.m
@@ -18,7 +18,7 @@ CGPathRef CPTCreateRoundedRectPath(CGRect rect, CGFloat cornerRadius)
 #pragma clang diagnostic ignored "-Wunreachable-code"
 #pragma clang diagnostic ignored "-Wpointer-bool-conversion"
 
-        if ( CGPathCreateWithRoundedRect ) {
+        if ( &CGPathCreateWithRoundedRect ) {
             return CGPathCreateWithRoundedRect(rect, cornerRadius, cornerRadius, NULL);
         }
         else {


### PR DESCRIPTION
CPTPathExtensions.m:19:14: Address of function 'CGPathCreateWithRoundedRect' will always evaluate to 'true'