### PR TITLE
Initial implementation of new CPTScaleType, CPTScaleTypeLogModulus.

### DIFF
--- a/framework/Source/CPTDefinitions.h
+++ b/framework/Source/CPTDefinitions.h
@@ -163,7 +163,8 @@ typedef NS_ENUM (NSInteger, CPTScaleType) {
     CPTScaleTypeLog,      ///< Logarithmic axis scale
     CPTScaleTypeAngular,  ///< Angular axis scale (not implemented)
     CPTScaleTypeDateTime, ///< Date/time axis scale (not implemented)
-    CPTScaleTypeCategory  ///< Category axis scale
+    CPTScaleTypeCategory, ///< Category axis scale
+    CPTScaleTypeLogModulus ///< Log-modulus axis scale
 };
 
 /**

--- a/framework/Source/CPTPlot.m
+++ b/framework/Source/CPTPlot.m
@@ -941,6 +941,7 @@ NSString *const CPTPlotBindingDataLabels = @"dataLabels"; ///< Plot data labels.
         switch ( [thePlotSpace scaleTypeForCoordinate:coordinate] ) {
             case CPTScaleTypeLinear:
             case CPTScaleTypeLog:
+            case CPTScaleTypeLogModulus:
             {
                 CPTMutableNumericData *mutableNumbers = [self numericDataForNumbers:numbers];
 
@@ -1035,6 +1036,7 @@ NSString *const CPTPlotBindingDataLabels = @"dataLabels"; ///< Plot data labels.
         switch ( [thePlotSpace scaleTypeForCoordinate:coordinate] ) {
             case CPTScaleTypeLinear:
             case CPTScaleTypeLog:
+            case CPTScaleTypeLogModulus:
             {
                 mutableNumbers = [self numericDataForNumbers:numbers];
 

--- a/framework/Source/CPTUtilities.h
+++ b/framework/Source/CPTUtilities.h
@@ -148,6 +148,12 @@ CPTEdgeInsets CPTEdgeInsetsMake(CGFloat top, CGFloat left, CGFloat bottom, CGFlo
 BOOL CPTEdgeInsetsEqualToEdgeInsets(CPTEdgeInsets insets1, CPTEdgeInsets insets2);
 
 /// @}
+    
+/// @name Log Modulus Definition
+/// @{
+double CPTLogModulus(double value);
+    
+/// @}
 
 #if __cplusplus
 }

--- a/framework/Source/CPTUtilities.m
+++ b/framework/Source/CPTUtilities.m
@@ -1004,3 +1004,12 @@ BOOL CPTEdgeInsetsEqualToEdgeInsets(CPTEdgeInsets insets1, CPTEdgeInsets insets2
            (insets1.bottom == insets2.bottom) &&
            (insets1.right == insets2.right);
 }
+
+#pragma mark -
+#pragma mark Log Modulus Definition
+
+double CPTLogModulus(double value)
+{
+    double sign = (value < 0) ? -1.0 : +1.0;
+    return sign * log10(fabs(value) + 1);
+}

--- a/framework/Source/CPTXYAxis.m
+++ b/framework/Source/CPTXYAxis.m
@@ -718,6 +718,15 @@
             }
             break;
 
+            case CPTScaleTypeLogModulus:
+            {
+                double loc = axisRange.locationDouble;
+                double end = axisRange.endDouble;
+                
+                location = @( pow(10.0, ( CPTLogModulus(loc) + CPTLogModulus(end) ) / 2.0) );
+            }
+                break;
+                
             default:
                 location = axisRange.midPoint;
                 break;


### PR DESCRIPTION
This is an implementation of a log modulus axis type. The log modulus transform is:

    log modulus (x) = sign(x) * log10(abs(x) + 1)

It allows one to plot negative values on a log scale. I tested this in a sample application and it seemed to work well, with one notable exception. Dragging to scroll the image is tied to the scale, not the pixels on screen, i.e. dragging near zero requires a many swipes to move the plot a little, but away from zero the swiping is too fast. The axis number scheme can be improved as well.

A reference on this type of plot can be found here:
http://blogs.sas.com/content/iml/2014/07/14/log-transformation-of-pos-neg.html