### PR TITLE
FIX:iOS5 support. NSForegroundColorAttributeName -> iOS6

### DIFF
--- a/framework/iPhoneOnly/CPTTextStylePlatformSpecific.m
+++ b/framework/iPhoneOnly/CPTTextStylePlatformSpecific.m
@@ -260,8 +260,12 @@
                    context:nil];
     }
     else {
-        UIColor *styleColor = style.attributes[NSForegroundColorAttributeName];
-        [styleColor set];
+        BOOL hasColorAttributeName = (&NSForegroundColorAttributeName != NULL);
+
+        if (hasColorAttributeName) {
+            UIColor *styleColor = style.attributes[NSForegroundColorAttributeName];
+            [styleColor set];
+        }
 
         UIFont *theFont    = nil;
         NSString *fontName = style.fontName;
@@ -279,9 +283,14 @@
 #pragma clang diagnostic pop
     }
 #else
-    UIColor *styleColor = style.attributes[NSForegroundColorAttributeName];
-    [styleColor set];
+    
+    BOOL hasColorAttributeName = (&NSForegroundColorAttributeName != NULL);
 
+    if (hasColorAttributeName) {
+        UIColor *styleColor = style.attributes[NSForegroundColorAttributeName];
+        [styleColor set];
+    }
+    
     UIFont *theFont = [UIFont fontWithName:style.fontName size:style.fontSize];
 
     [self drawInRect:rect


### PR DESCRIPTION
Missing test on iOS version for this key