### PR TITLE
Add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Core Plot
+
+*Cocoa plotting framework for Mac OS X and iOS.*
+
+[![Build Status](https://secure.travis-ci.org/core-plot/core-plot.svg)](http://travis-ci.org/core-plot/core-plot) [![Version Status](https://img.shields.io/cocoapods/v/CorePlot.svg)](https://cocoapods.org/pods/CorePlot) [![license MIT](https://img.shields.io/cocoapods/l/CorePlot.svg)](http://opensource.org/licenses/BSD-3-Clause)  [![Platform](https://img.shields.io/cocoapods/p/CorePlot.svg)](http://core-plot.github.io)
+
 # Introduction
 
 Core Plot is a 2D plotting framework for Mac OS X and iOS. It is highly customizable and capable of drawing many types of plots. See the  [Example Graphs](https://github.com/core-plot/core-plot/wiki/Example-Graphs) wiki page and the [example applications](https://github.com/core-plot/core-plot/tree/master/examples) for examples of some of its capabilities.


### PR DESCRIPTION
Hey @eskroch!

I've added the following to the README:

- Travis-CI build status badge (links to build page)
- Pod version badge (links to cocoapods page)
- License badge (links to license on opensource.org)
- Platform badge (links to docs)

See the rendered page [here](https://github.com/jessesquires/core-plot/blob/master/README.md).

I find these to be extremely helpful in my own projects to allow everyone to get a quick glance of project status.

Hope you'll merge! :smile: 