### PR TITLE
Fix Version number for carthage builds

### DIFF
--- a/framework/CorePlot_iOS-Info.plist
+++ b/framework/CorePlot_iOS-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>2.0</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
I'm building CorePlot with `carthage` (maybe not fully supported) but when I upload an app with CorePlot (as-is) I get the error

> [10:40:02]: ERROR ITMS-90056: "This bundle Payload/<APPNAME>/Frameworks/CorePlot.framework is invalid. The Info.plist file is missing the required key: CFBundleVersion."

Looking inside the `info.plist` in the framework itself this value is set to

    <key><CFBundleVersion></key>
    <string></string>

So the `2.0`here fixes my error - by correctly propagating the 2.0 into the `Info.plist` of the resulting framework