### PR TITLE
add Catmull-Rom interpolation algorithm plot drawing. Fixed issue #68.

### DIFF
--- a/framework/CorePlot.xcodeproj/project.pbxproj
+++ b/framework/CorePlot.xcodeproj/project.pbxproj
@@ -157,6 +157,14 @@
 		906156BE0F375598001B75FC /* CPTLineStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 906156BC0F375598001B75FC /* CPTLineStyle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		906156BF0F375598001B75FC /* CPTLineStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = 906156BD0F375598001B75FC /* CPTLineStyle.m */; };
 		90AF4FBA0F36D39700753D26 /* CPTXYPlotSpace.m in Sources */ = {isa = PBXBuildFile; fileRef = 90AF4FB90F36D39700753D26 /* CPTXYPlotSpace.m */; };
+		93961BE61C71ACFD002F5A58 /* CPTCatmullRomInterpolation.h in Headers */ = {isa = PBXBuildFile; fileRef = 93961BE51C71ACFD002F5A58 /* CPTCatmullRomInterpolation.h */; };
+		93961BE71C71ACFD002F5A58 /* CPTCatmullRomInterpolation.h in Headers */ = {isa = PBXBuildFile; fileRef = 93961BE51C71ACFD002F5A58 /* CPTCatmullRomInterpolation.h */; };
+		93961BE91C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */ = {isa = PBXBuildFile; fileRef = 93961BE81C71AD57002F5A58 /* CPTCatmullRomInterpolation.m */; };
+		93961BEA1C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */ = {isa = PBXBuildFile; fileRef = 93961BE81C71AD57002F5A58 /* CPTCatmullRomInterpolation.m */; };
+		93961BEB1C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */ = {isa = PBXBuildFile; fileRef = 93961BE81C71AD57002F5A58 /* CPTCatmullRomInterpolation.m */; };
+		93961BEC1C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */ = {isa = PBXBuildFile; fileRef = 93961BE81C71AD57002F5A58 /* CPTCatmullRomInterpolation.m */; };
+		93961BED1C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */ = {isa = PBXBuildFile; fileRef = 93961BE81C71AD57002F5A58 /* CPTCatmullRomInterpolation.m */; };
+		93961BEE1C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */ = {isa = PBXBuildFile; fileRef = 93961BE81C71AD57002F5A58 /* CPTCatmullRomInterpolation.m */; };
 		A92C00498745CB844AF563E0 /* _CPTAnimationCGRectPeriod.h in Headers */ = {isa = PBXBuildFile; fileRef = A92C0E876AE37EB30019586B /* _CPTAnimationCGRectPeriod.h */; };
 		A92C02A48B4FBD94D718ECF8 /* _CPTAnimationCGSizePeriod.m in Sources */ = {isa = PBXBuildFile; fileRef = A92C087BF0913A6BA2363E40 /* _CPTAnimationCGSizePeriod.m */; };
 		A92C02FFEE33F8D28665257B /* _CPTAnimationNSDecimalPeriod.m in Sources */ = {isa = PBXBuildFile; fileRef = A92C00B71DCB2085A92BE0A9 /* _CPTAnimationNSDecimalPeriod.m */; };
@@ -787,6 +795,8 @@
 		906156BC0F375598001B75FC /* CPTLineStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = CPTLineStyle.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		906156BD0F375598001B75FC /* CPTLineStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CPTLineStyle.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		90AF4FB90F36D39700753D26 /* CPTXYPlotSpace.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CPTXYPlotSpace.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		93961BE51C71ACFD002F5A58 /* CPTCatmullRomInterpolation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPTCatmullRomInterpolation.h; sourceTree = "<group>"; };
+		93961BE81C71AD57002F5A58 /* CPTCatmullRomInterpolation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CPTCatmullRomInterpolation.m; sourceTree = "<group>"; };
 		A92C00B71DCB2085A92BE0A9 /* _CPTAnimationNSDecimalPeriod.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _CPTAnimationNSDecimalPeriod.m; sourceTree = "<group>"; };
 		A92C0563E082D1C1E249FA6F /* _CPTAnimationCGSizePeriod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _CPTAnimationCGSizePeriod.h; sourceTree = "<group>"; };
 		A92C0685ACE3281299F10F73 /* _CPTAnimationNSDecimalPeriod.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _CPTAnimationNSDecimalPeriod.h; sourceTree = "<group>"; };
@@ -1213,6 +1223,8 @@
 		07BF0D890F2B736D002FCEA7 /* Plots */ = {
 			isa = PBXGroup;
 			children = (
+				93961BE51C71ACFD002F5A58 /* CPTCatmullRomInterpolation.h */,
+				93961BE81C71AD57002F5A58 /* CPTCatmullRomInterpolation.m */,
 				C3F31DE81045EB470058520A /* CPTPlotGroup.h */,
 				C3F31DE71045EB470058520A /* CPTPlotGroup.m */,
 				07BF0D7E0F2B72F6002FCEA7 /* CPTPlot.h */,
@@ -1797,6 +1809,7 @@
 				072161EB11D1F6BD009CC871 /* CPTAnnotationHostLayer.h in Headers */,
 				C318F4AD11EA188700595FF9 /* CPTLimitBand.h in Headers */,
 				C3CAFB261229E41F00F5C989 /* CPTMutableNumericData+TypeConversion.h in Headers */,
+				93961BE61C71ACFD002F5A58 /* CPTCatmullRomInterpolation.h in Headers */,
 				C3CCA03D13E8D85900CE6DB1 /* _CPTConstraintsFixed.h in Headers */,
 				C3CCA03F13E8D85900CE6DB1 /* _CPTConstraintsRelative.h in Headers */,
 				07B69A5D12B6215000F4C16C /* CPTTextStyle.h in Headers */,
@@ -1831,6 +1844,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C38A0AAF1A46241100D45436 /* CPTLimitBand.h in Headers */,
+				93961BE71C71ACFD002F5A58 /* CPTCatmullRomInterpolation.h in Headers */,
 				C38A09EF1A461CD000D45436 /* CPTDefinitions.h in Headers */,
 				C38A0AD51A46256B00D45436 /* CPTPlotSymbol.h in Headers */,
 				C38A0AC61A46255C00D45436 /* CPTTradingRangePlot.h in Headers */,
@@ -2208,6 +2222,7 @@
 				C3392A481225FB68008DA6BD /* CPTMutableNumericDataTests.m in Sources */,
 				C3392A491225FB69008DA6BD /* CPTNumericDataTests.m in Sources */,
 				C3BFFD1112274CB500DE22AC /* CPTNumericDataTypeConversionTests.m in Sources */,
+				93961BEA1C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */,
 				C3CB561C122A9E9F00FBFB61 /* CPTMutableNumericDataTypeConversionTests.m in Sources */,
 				C3D979A413D2136700145DFF /* CPTPlotSpaceTests.m in Sources */,
 				C3D979A913D2328000145DFF /* CPTTimeFormatterTests.m in Sources */,
@@ -2263,6 +2278,7 @@
 				070622330FDF1B250066A6C4 /* CPTPathExtensions.m in Sources */,
 				0706223D0FDF215C0066A6C4 /* CPTBorderedLayer.m in Sources */,
 				07C4679C0FE1A24C00299939 /* CPTMutableTextStyle.m in Sources */,
+				93961BE91C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */,
 				07C467B90FE1A96E00299939 /* CPTTextStylePlatformSpecific.m in Sources */,
 				0772C9280FE2F71600EC4C16 /* CPTTheme.m in Sources */,
 				0772C9300FE2F89000EC4C16 /* _CPTDarkGradientTheme.m in Sources */,
@@ -2411,6 +2427,7 @@
 				C38A0A091A461D4D00D45436 /* CPTBorderedLayer.m in Sources */,
 				C38A0A6B1A4620E200D45436 /* CPTLineStyle.m in Sources */,
 				C38A0A241A461E9200D45436 /* _CPTAnimationCGSizePeriod.m in Sources */,
+				93961BEB1C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */,
 				C38A0ACA1A46256500D45436 /* CPTPieChart.m in Sources */,
 				C38A0A671A4620E200D45436 /* CPTColorSpace.m in Sources */,
 				C38A0A681A4620E200D45436 /* CPTGradient.m in Sources */,
@@ -2442,6 +2459,7 @@
 				C38A09D31A461C1800D45436 /* CPTDataSourceTestCase.m in Sources */,
 				C38A09E81A461CB600D45436 /* CPTNumericDataTests.m in Sources */,
 				C38A0B141A46261F00D45436 /* CPTDerivedXYGraph.m in Sources */,
+				93961BEC1C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */,
 				C38A0ABD1A46250B00D45436 /* CPTXYPlotSpaceTests.m in Sources */,
 				C38A09D11A461C1100D45436 /* CPTTestCase.m in Sources */,
 				C38A0A011A461D2E00D45436 /* CPTPlotRangeTests.m in Sources */,
@@ -2543,6 +2561,7 @@
 				C38A0A311A461EB600D45436 /* _CPTAnimationTimingFunctions.m in Sources */,
 				C38A0A5B1A4620B800D45436 /* CPTImagePlatformSpecific.m in Sources */,
 				C38A0A4C1A461F1B00D45436 /* CPTTextStyle.m in Sources */,
+				93961BED1C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */,
 				C38A0B101A46261700D45436 /* _CPTSlateTheme.m in Sources */,
 				C38A0AD31A46256600D45436 /* CPTScatterPlot.m in Sources */,
 				C38A0A0D1A461D5800D45436 /* _CPTBorderLayer.m in Sources */,
@@ -2574,6 +2593,7 @@
 				C38A0A911A46210A00D45436 /* CPTLineStyleTests.m in Sources */,
 				C38A0A021A461D2E00D45436 /* CPTPlotRangeTests.m in Sources */,
 				C38A0B171A46262000D45436 /* CPTDerivedXYGraph.m in Sources */,
+				93961BEE1C71AD57002F5A58 /* CPTCatmullRomInterpolation.m in Sources */,
 				C38A09E71A461CB300D45436 /* CPTMutableNumericDataTypeConversionTests.m in Sources */,
 				C38A0A8E1A46210A00D45436 /* CPTFillTests.m in Sources */,
 				C38A09E91A461CB700D45436 /* CPTNumericDataTests.m in Sources */,

--- a/framework/Source/CPTCatmullRomInterpolation.h
+++ b/framework/Source/CPTCatmullRomInterpolation.h
@@ -1,0 +1,17 @@
+//
+// Created by Mikkel Gravgaard on 27/11/14.
+// From this post: http://stackoverflow.com/questions/9489736/catmull-rom-curve-with-no-cusps-and-no-self-intersections
+//
+
+#import <Foundation/Foundation.h>
+
+typedef enum {
+    CatmullRomTypeUniform,
+    CatmullRomTypeChordal,
+    CatmullRomTypeCentripetal
+}
+CatmullRomType;
+
+@interface CPTCatmullRomInterpolation : NSObject
++(UIBezierPath *)bezierPathFromPoints:(NSArray *)points withGranularity:(NSInteger)granularity;
+@end

--- a/framework/Source/CPTCatmullRomInterpolation.m
+++ b/framework/Source/CPTCatmullRomInterpolation.m
@@ -1,0 +1,137 @@
+//
+// Created by Mikkel Gravgaard on 27/11/14.
+// From this post: http://stackoverflow.com/questions/9489736/catmull-rom-curve-with-no-cusps-and-no-self-intersections
+//
+
+#import "CPTCatmullRomInterpolation.h"
+
+@implementation CPTCatmullRomInterpolation
+
++(UIBezierPath *)bezierPathFromPoints:(NSArray *)points withGranularity:(NSInteger)granularity
+{
+    UIBezierPath __block *path = [[UIBezierPath alloc] init];
+    
+    NSMutableArray *curve = [self interpolate:points withPointsPerSegment:granularity andType:CatmullRomTypeCentripetal];
+    
+    CGPoint __block p0 = [curve[0] CGPointValue];
+    
+    [path moveToPoint:p0];
+    
+    //use this loop to draw lines between all points
+    for ( NSUInteger idx = 1; (idx < [curve count]); idx += 1 ) {
+        CGPoint c1 = [curve[idx] CGPointValue];
+        
+        [path addLineToPoint:c1];
+    }
+    
+    return path;
+}
+
++(NSMutableArray *)interpolate:(NSArray *)coordinates withPointsPerSegment:(NSInteger)pointsPerSegment andType:(CatmullRomType)curveType
+{
+    NSMutableArray *vertices = [[NSMutableArray alloc] initWithArray:coordinates copyItems:YES];
+    
+    if ( pointsPerSegment < 3 ) {
+        return vertices;
+    }
+    
+    //start point
+    CGPoint pt1 = [vertices[0] CGPointValue];
+    CGPoint pt2 = [vertices[1] CGPointValue];
+    
+    double dx = pt2.x - pt1.x;
+    double dy = pt2.y - pt1.y;
+    
+    double x1 = pt1.x - dx;
+    double y1 = pt1.y - dy;
+    
+    CGPoint start = CGPointMake(x1 * .5, y1);
+    
+    //end point
+    pt2 = [vertices[vertices.count - 1] CGPointValue];
+    pt1 = [vertices[vertices.count - 2] CGPointValue];
+    
+    dx = pt2.x - pt1.x;
+    dy = pt2.y - pt1.y;
+    
+    x1 = pt2.x + dx;
+    y1 = pt2.y + dy;
+    
+    CGPoint end = CGPointMake(x1, y1);
+    
+    [vertices insertObject:[NSValue valueWithCGPoint:start] atIndex:0];
+    [vertices addObject:[NSValue valueWithCGPoint:end]];
+    
+    NSMutableArray *result = [NSMutableArray array];
+    
+    for ( int i = 0; i < (int)(vertices.count - 3); i++ ) {
+        NSMutableArray *points = [self interpolate:vertices forIndex:i withPointsPerSegment:pointsPerSegment andType:curveType];
+        [result addObjectsFromArray:points];
+    }
+    
+    return result;
+}
+
++(double)interpolate:(double *)p time:(double *)time t:(double)t
+{
+    double L01  = p[0] * (time[1] - t) / (time[1] - time[0]) + p[1] * (t - time[0]) / (time[1] - time[0]);
+    double L12  = p[1] * (time[2] - t) / (time[2] - time[1]) + p[2] * (t - time[1]) / (time[2] - time[1]);
+    double L23  = p[2] * (time[3] - t) / (time[3] - time[2]) + p[3] * (t - time[2]) / (time[3] - time[2]);
+    double L012 = L01 * (time[2] - t) / (time[2] - time[0]) + L12 * (t - time[0]) / (time[2] - time[0]);
+    double L123 = L12 * (time[3] - t) / (time[3] - time[1]) + L23 * (t - time[1]) / (time[3] - time[1]);
+    double C12  = L012 * (time[2] - t) / (time[2] - time[1]) + L123 * (t - time[1]) / (time[2] - time[1]);
+    
+    return C12;
+}
+
++(NSMutableArray *)interpolate:(NSArray *)points forIndex:(NSInteger)index withPointsPerSegment:(NSInteger)pointsPerSegment andType:(CatmullRomType)curveType
+{
+    NSMutableArray *result = [NSMutableArray array];
+    
+    double x[4];
+    double y[4];
+    double time[4];
+    
+    for ( int i = 0; i < 4; i++ ) {
+        x[i]    = [points[(NSUInteger)(index + i)] CGPointValue].x;
+        y[i]    = [points[(NSUInteger)(index + i)] CGPointValue].y;
+        time[i] = i;
+    }
+    
+    double tstart = 1;
+    double tend   = 2;
+    
+    if ( curveType != CatmullRomTypeUniform ) {
+        double total = 0;
+        
+        for ( int i = 1; i < 4; i++ ) {
+            double dx = x[i] - x[i - 1];
+            double dy = y[i] - y[i - 1];
+            
+            if ( curveType == CatmullRomTypeCentripetal ) {
+                total += pow(dx * dx + dy * dy, 0.25);
+            }
+            else {
+                total += pow(dx * dx + dy * dy, 0.5);
+            }
+            time[i] = total;
+        }
+        tstart = time[1];
+        tend   = time[2];
+    }
+    
+    long segments = pointsPerSegment - 1;
+    
+    [result addObject:points[(NSUInteger)(index + 1)]];
+    
+    for ( int i = 1; i < segments; i++ ) {
+        double xi = [self interpolate:x time:time t:tstart + ( i * (tend - tstart) ) / segments];
+        double yi = [self interpolate:y time:time t:tstart + ( i * (tend - tstart) ) / segments];
+        [result addObject:[NSValue valueWithCGPoint:CGPointMake(xi, yi)]];
+    }
+    [result addObject:points[(NSUInteger)(index + 2)]];
+    
+    return result;
+}
+
+@end

--- a/framework/Source/CPTScatterPlot.h
+++ b/framework/Source/CPTScatterPlot.h
@@ -31,7 +31,8 @@ typedef NS_ENUM (NSInteger, CPTScatterPlotInterpolation) {
     CPTScatterPlotInterpolationLinear,    ///< Linear interpolation.
     CPTScatterPlotInterpolationStepped,   ///< Steps beginning at data point.
     CPTScatterPlotInterpolationHistogram, ///< Steps centered at data point.
-    CPTScatterPlotInterpolationCurved     ///< Bezier curve interpolation.
+    CPTScatterPlotInterpolationCurved,    ///< Bezier curve interpolation.
+    CPTScatterPlotInterpolationCatmullRom ///< Catmull-Rom interpolation.
 };
 
 /**

--- a/framework/Source/CPTScatterPlot.m
+++ b/framework/Source/CPTScatterPlot.m
@@ -13,6 +13,7 @@
 #import "CPTUtilities.h"
 #import "CPTXYPlotSpace.h"
 #import "NSCoderExtensions.h"
+#import "CPTCatmullRomInterpolation.h"
 #import <tgmath.h>
 
 /** @defgroup plotAnimationScatterPlot Scatter Plot
@@ -430,7 +431,7 @@ NSString *const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; ///< Plot sym
 
     CPTLineStyle *lineStyle = self.dataLineStyle;
 
-    if ( self.areaFill || self.areaFill2 || lineStyle.dashPattern || lineStyle.lineFill || (self.interpolation == CPTScatterPlotInterpolationCurved) ) {
+    if ( self.areaFill || self.areaFill2 || lineStyle.dashPattern || lineStyle.lineFill || (self.interpolation == CPTScatterPlotInterpolationCurved) || (self.interpolation == CPTScatterPlotInterpolationCatmullRom) ) {
         // show all points to preserve the line dash and area fills
         for ( NSUInteger i = 0; i < dataCount; i++ ) {
             pointDrawFlags[i] = YES;
@@ -508,6 +509,7 @@ NSString *const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; ///< Plot sym
         else {
             switch ( theInterpolation ) {
                 case CPTScatterPlotInterpolationCurved:
+                case CPTScatterPlotInterpolationCatmullRom:
                     // Keep 2 points outside of the visible area on each side to maintain the correct curvature of the line
                     if ( dataCount > 1 ) {
                         if ( !nanFlags[0] && !nanFlags[1] && ( (xRangeFlags[0] != xRangeFlags[1]) || (yRangeFlags[0] != yRangeFlags[1]) ) ) {
@@ -924,6 +926,9 @@ NSString *const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; ///< Plot sym
     if ( theInterpolation == CPTScatterPlotInterpolationCurved ) {
         return [self newCurvedDataLinePathForViewPoints:viewPoints indexRange:indexRange baselineYValue:baselineYValue];
     }
+    else if ( theInterpolation == CPTScatterPlotInterpolationCatmullRom ) {
+        return [self newCatmullRomDataLinePathForViewPoints:viewPoints indexRange:indexRange baselineYValue:baselineYValue];
+    }
 
     CGMutablePathRef dataLinePath  = CGPathCreateMutable();
     BOOL lastPointSkipped          = YES;
@@ -979,6 +984,7 @@ NSString *const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; ///< Plot sym
                     break;
 
                     case CPTScatterPlotInterpolationCurved:
+                    case CPTScatterPlotInterpolationCatmullRom:
                         // Curved plot lines handled separately
                         break;
                 }
@@ -1191,6 +1197,36 @@ NSString *const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; ///< Plot sym
         free(r);
     }
 }
+
+-(CGPathRef)newCatmullRomDataLinePathForViewPoints:(CGPoint *)viewPoints indexRange:(NSRange)indexRange baselineYValue:(CGFloat)baselineYValue
+{
+    CGMutablePathRef dataLinePath  = CGPathCreateMutable();
+    NSUInteger pointsSize = indexRange.length;
+    
+    if ( pointsSize >= 2 ) {
+        NSMutableArray * inputPoints = [NSMutableArray array];
+        
+        for( int i = (int)indexRange.location; i< (int)( indexRange.location + pointsSize ); i++ ){
+            CGPoint p = viewPoints[i];
+            CGPoint q = CGPointMake(p.x, p.y);
+            [inputPoints addObject:[NSValue valueWithCGPoint:q]];
+        }
+        
+        UIBezierPath* bezierPath = [CPTCatmullRomInterpolation bezierPathFromPoints:inputPoints withGranularity:20];
+        dataLinePath = CGPathCreateCopy(bezierPath.CGPath);
+        
+        if ( !isnan(baselineYValue) ) {
+            CGPoint firstPoint = viewPoints[0];
+            CGPoint lastPoint = viewPoints[pointsSize - 1];
+            CGPathAddLineToPoint(dataLinePath, NULL, lastPoint.x, baselineYValue);
+            CGPathAddLineToPoint(dataLinePath, NULL, firstPoint.x, baselineYValue);
+            CGPathCloseSubpath(dataLinePath);
+        }
+    }
+    return dataLinePath;
+}
+
+
 
 -(void)drawSwatchForLegend:(CPTLegend *)legend atIndex:(NSUInteger)idx inRect:(CGRect)rect inContext:(CGContextRef)context
 {

--- a/framework/Source/CPTScatterPlot.m
+++ b/framework/Source/CPTScatterPlot.m
@@ -1,5 +1,7 @@
 #import "CPTScatterPlot.h"
 
+#import <UIKit/UIKit.h>
+#import <tgmath.h>
 #import "CPTExceptions.h"
 #import "CPTFill.h"
 #import "CPTLegend.h"
@@ -14,7 +16,6 @@
 #import "CPTXYPlotSpace.h"
 #import "NSCoderExtensions.h"
 #import "CPTCatmullRomInterpolation.h"
-#import <tgmath.h>
 
 /** @defgroup plotAnimationScatterPlot Scatter Plot
  *  @brief Scatter plot properties that can be animated using Core Animation.


### PR DESCRIPTION
Inspired by [grav's branch](https://github.com/grav/core-plot/tree/catmullrom) and [nh32rg's post](http://stackoverflow.com/questions/9489736/catmull-rom-curve-with-no-cusps-and-no-self-intersections). 

Using a slightly modified version of CPTTestApp-iPhone, the result is the following: 
![coreplot-curved-vs-catmullrom](https://cloud.githubusercontent.com/assets/17201662/13049981/c66a0eb0-d3f0-11e5-8a3e-1d02607d1df4.png)


