### PR TITLE
Add new interpolation methods for curved scatter plot.

### DIFF
--- a/examples/CorePlotGallery/Plot_Gallery.xcodeproj/project.pbxproj
+++ b/examples/CorePlotGallery/Plot_Gallery.xcodeproj/project.pbxproj
@@ -30,50 +30,50 @@
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		C30B12431BCADD300084C567 /* CorePlot.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C3D4146F1A7D824700B6F5D6 /* CorePlot.framework */; };
 		C30B12441BCADD300084C567 /* CorePlot.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C3D4146F1A7D824700B6F5D6 /* CorePlot.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		C30B12481BCADE170084C567 /* PlotItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FFAE12342DB1006BF615 /* PlotItem.m */; settings = {ASSET_TAGS = (); }; };
-		C30B12491BCADE170084C567 /* PlotGallery.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FFAC12342DB1006BF615 /* PlotGallery.m */; settings = {ASSET_TAGS = (); }; };
-		C30B124A1BCADE170084C567 /* PiNumberFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = C3457A4C17AD7C5D000880F3 /* PiNumberFormatter.m */; settings = {ASSET_TAGS = (); }; };
+		C30B12481BCADE170084C567 /* PlotItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FFAE12342DB1006BF615 /* PlotItem.m */; };
+		C30B12491BCADE170084C567 /* PlotGallery.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FFAC12342DB1006BF615 /* PlotGallery.m */; };
+		C30B124A1BCADE170084C567 /* PiNumberFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = C3457A4C17AD7C5D000880F3 /* PiNumberFormatter.m */; };
 		C3457A4D17AD7C5D000880F3 /* PiNumberFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = C3457A4C17AD7C5D000880F3 /* PiNumberFormatter.m */; };
-		C34CB5461BC9A83C009270A0 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C34CB5451BC9A83C009270A0 /* Images.xcassets */; settings = {ASSET_TAGS = (); }; };
-		C34CB5541BC9A889009270A0 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C34CB5481BC9A889009270A0 /* AppDelegate.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5551BC9A889009270A0 /* DetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C34CB54A1BC9A889009270A0 /* DetailViewController.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5561BC9A889009270A0 /* Launch Screen.xib in Resources */ = {isa = PBXBuildFile; fileRef = C34CB54B1BC9A889009270A0 /* Launch Screen.xib */; settings = {ASSET_TAGS = (); }; };
-		C34CB5571BC9A889009270A0 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C34CB54C1BC9A889009270A0 /* main.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5581BC9A889009270A0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C34CB54D1BC9A889009270A0 /* Main.storyboard */; settings = {ASSET_TAGS = (); }; };
-		C34CB55A1BC9A889009270A0 /* RootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C34CB5511BC9A889009270A0 /* RootViewController.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB55B1BC9A889009270A0 /* ThemeTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C34CB5531BC9A889009270A0 /* ThemeTableViewController.m */; settings = {ASSET_TAGS = (); }; };
+		C34CB5461BC9A83C009270A0 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C34CB5451BC9A83C009270A0 /* Images.xcassets */; };
+		C34CB5541BC9A889009270A0 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C34CB5481BC9A889009270A0 /* AppDelegate.m */; };
+		C34CB5551BC9A889009270A0 /* DetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C34CB54A1BC9A889009270A0 /* DetailViewController.m */; };
+		C34CB5561BC9A889009270A0 /* Launch Screen.xib in Resources */ = {isa = PBXBuildFile; fileRef = C34CB54B1BC9A889009270A0 /* Launch Screen.xib */; };
+		C34CB5571BC9A889009270A0 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C34CB54C1BC9A889009270A0 /* main.m */; };
+		C34CB5581BC9A889009270A0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C34CB54D1BC9A889009270A0 /* Main.storyboard */; };
+		C34CB55A1BC9A889009270A0 /* RootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C34CB5511BC9A889009270A0 /* RootViewController.m */; };
+		C34CB55B1BC9A889009270A0 /* ThemeTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C34CB5531BC9A889009270A0 /* ThemeTableViewController.m */; };
 		C34CB5601BC9AB7B009270A0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C34CB55F1BC9AB7B009270A0 /* Foundation.framework */; };
 		C34CB5621BC9AB85009270A0 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C34CB5611BC9AB85009270A0 /* UIKit.framework */; };
 		C34CB5641BC9AB8C009270A0 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C34CB5631BC9AB8C009270A0 /* CoreGraphics.framework */; };
 		C34CB5661BC9AB93009270A0 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C34CB5651BC9AB93009270A0 /* QuartzCore.framework */; };
 		C34CB5681BC9AB9E009270A0 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C34CB5671BC9AB9E009270A0 /* Accelerate.framework */; };
-		C34CB57C1BC9B1C1009270A0 /* AxisDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E1CC112908B0000D2035F /* AxisDemo.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB57D1BC9B1C1009270A0 /* CandlestickPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C360E1DF13B18CAE007994B6 /* CandlestickPlot.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB57E1BC9B1C1009270A0 /* ColoredBarChart.m in Sources */ = {isa = PBXBuildFile; fileRef = C3A31A5514DF782A00734AB7 /* ColoredBarChart.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB57F1BC9B1C1009270A0 /* CompositePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FF9B12342D7C006BF615 /* CompositePlot.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5801BC9B1C1009270A0 /* ControlChart.m in Sources */ = {isa = PBXBuildFile; fileRef = C35597951437E07800B41DA7 /* ControlChart.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5811BC9B1C1009270A0 /* CurvedScatterPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C3F42A2714D3A75F0044B323 /* CurvedScatterPlot.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5821BC9B1C1009270A0 /* DatePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E1C13129077C200D2035F /* DatePlot.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5831BC9B1C1009270A0 /* DonutChart.m in Sources */ = {isa = PBXBuildFile; fileRef = C3F34F1412AB2598008FBDC3 /* DonutChart.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5841BC9B1C1009270A0 /* FunctionPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C3F97F1817A9DE2000A52FF2 /* FunctionPlot.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5851BC9B1C1009270A0 /* GradientScatterPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FF9D12342D7C006BF615 /* GradientScatterPlot.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5861BC9B1C1009270A0 /* ImageDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C3D70BA5175EB29E00F27173 /* ImageDemo.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5871BC9B1C1009270A0 /* LabelingPolicyDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C39C4E4013BFE1A900CD9194 /* LabelingPolicyDemo.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5881BC9B1C1009270A0 /* LineCapDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C367249213E103910070F47A /* LineCapDemo.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5891BC9B1C1009270A0 /* OHLCPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C360E1C513B18AAF007994B6 /* OHLCPlot.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB58A1BC9B1C1009270A0 /* PlotSpaceDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C39C4E4313BFE1B400CD9194 /* PlotSpaceDemo.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB58B1BC9B1C1009270A0 /* RangePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C3A14BEB13AEB7E700D103EA /* RangePlot.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB58C1BC9B1C1009270A0 /* RealTimePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C354C0D613C7CDBE00DA8822 /* RealTimePlot.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB58D1BC9B1C1009270A0 /* SteppedScatterPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E1C85129083B000D2035F /* SteppedScatterPlot.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB58E1BC9B1C1009270A0 /* SimplePieChart.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FF9F12342D7C006BF615 /* SimplePieChart.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB58F1BC9B1C1009270A0 /* SimpleScatterPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FFA112342D7C006BF615 /* SimpleScatterPlot.m */; settings = {ASSET_TAGS = (); }; };
-		C34CB5901BC9B1C1009270A0 /* VerticalBarChart.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FFA312342D7C006BF615 /* VerticalBarChart.m */; settings = {ASSET_TAGS = (); }; };
+		C34CB57C1BC9B1C1009270A0 /* AxisDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E1CC112908B0000D2035F /* AxisDemo.m */; };
+		C34CB57D1BC9B1C1009270A0 /* CandlestickPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C360E1DF13B18CAE007994B6 /* CandlestickPlot.m */; };
+		C34CB57E1BC9B1C1009270A0 /* ColoredBarChart.m in Sources */ = {isa = PBXBuildFile; fileRef = C3A31A5514DF782A00734AB7 /* ColoredBarChart.m */; };
+		C34CB57F1BC9B1C1009270A0 /* CompositePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FF9B12342D7C006BF615 /* CompositePlot.m */; };
+		C34CB5801BC9B1C1009270A0 /* ControlChart.m in Sources */ = {isa = PBXBuildFile; fileRef = C35597951437E07800B41DA7 /* ControlChart.m */; };
+		C34CB5811BC9B1C1009270A0 /* CurvedScatterPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C3F42A2714D3A75F0044B323 /* CurvedScatterPlot.m */; };
+		C34CB5821BC9B1C1009270A0 /* DatePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E1C13129077C200D2035F /* DatePlot.m */; };
+		C34CB5831BC9B1C1009270A0 /* DonutChart.m in Sources */ = {isa = PBXBuildFile; fileRef = C3F34F1412AB2598008FBDC3 /* DonutChart.m */; };
+		C34CB5841BC9B1C1009270A0 /* FunctionPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C3F97F1817A9DE2000A52FF2 /* FunctionPlot.m */; };
+		C34CB5851BC9B1C1009270A0 /* GradientScatterPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FF9D12342D7C006BF615 /* GradientScatterPlot.m */; };
+		C34CB5861BC9B1C1009270A0 /* ImageDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C3D70BA5175EB29E00F27173 /* ImageDemo.m */; };
+		C34CB5871BC9B1C1009270A0 /* LabelingPolicyDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C39C4E4013BFE1A900CD9194 /* LabelingPolicyDemo.m */; };
+		C34CB5881BC9B1C1009270A0 /* LineCapDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C367249213E103910070F47A /* LineCapDemo.m */; };
+		C34CB5891BC9B1C1009270A0 /* OHLCPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C360E1C513B18AAF007994B6 /* OHLCPlot.m */; };
+		C34CB58A1BC9B1C1009270A0 /* PlotSpaceDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C39C4E4313BFE1B400CD9194 /* PlotSpaceDemo.m */; };
+		C34CB58B1BC9B1C1009270A0 /* RangePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C3A14BEB13AEB7E700D103EA /* RangePlot.m */; };
+		C34CB58C1BC9B1C1009270A0 /* RealTimePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C354C0D613C7CDBE00DA8822 /* RealTimePlot.m */; };
+		C34CB58D1BC9B1C1009270A0 /* SteppedScatterPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E1C85129083B000D2035F /* SteppedScatterPlot.m */; };
+		C34CB58E1BC9B1C1009270A0 /* SimplePieChart.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FF9F12342D7C006BF615 /* SimplePieChart.m */; };
+		C34CB58F1BC9B1C1009270A0 /* SimpleScatterPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FFA112342D7C006BF615 /* SimpleScatterPlot.m */; };
+		C34CB5901BC9B1C1009270A0 /* VerticalBarChart.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22FFA312342D7C006BF615 /* VerticalBarChart.m */; };
 		C354C0D713C7CDBE00DA8822 /* RealTimePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C354C0D613C7CDBE00DA8822 /* RealTimePlot.m */; };
 		C35597961437E07800B41DA7 /* ControlChart.m in Sources */ = {isa = PBXBuildFile; fileRef = C35597951437E07800B41DA7 /* ControlChart.m */; };
 		C360E1C613B18AAF007994B6 /* OHLCPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C360E1C513B18AAF007994B6 /* OHLCPlot.m */; };
 		C360E1E013B18CAF007994B6 /* CandlestickPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C360E1DF13B18CAE007994B6 /* CandlestickPlot.m */; };
 		C367249313E103910070F47A /* LineCapDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C367249213E103910070F47A /* LineCapDemo.m */; };
-		C367EEE21BCAEA9E00A21FE7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C3D2FE6219FF1D03002CD4D6 /* Images.xcassets */; settings = {ASSET_TAGS = (); }; };
+		C367EEE21BCAEA9E00A21FE7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C3D2FE6219FF1D03002CD4D6 /* Images.xcassets */; };
 		C39C4E4113BFE1A900CD9194 /* LabelingPolicyDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C39C4E4013BFE1A900CD9194 /* LabelingPolicyDemo.m */; };
 		C39C4E4413BFE1B400CD9194 /* PlotSpaceDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C39C4E4313BFE1B400CD9194 /* PlotSpaceDemo.m */; };
 		C3A14BEC13AEB7E700D103EA /* RangePlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C3A14BEB13AEB7E700D103EA /* RangePlot.m */; };
@@ -84,6 +84,8 @@
 		C3EF42FD19FC75810060791A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C3EF42FC19FC75810060791A /* Images.xcassets */; };
 		C3F34F1512AB2598008FBDC3 /* DonutChart.m in Sources */ = {isa = PBXBuildFile; fileRef = C3F34F1412AB2598008FBDC3 /* DonutChart.m */; };
 		C3F97F1917A9DE2000A52FF2 /* FunctionPlot.m in Sources */ = {isa = PBXBuildFile; fileRef = C3F97F1817A9DE2000A52FF2 /* FunctionPlot.m */; };
+		E9595DFC1C9973B9004129DA /* CurvedInterpolationDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = E9595DFB1C9973B9004129DA /* CurvedInterpolationDemo.m */; };
+		E9AB989C1C9A903700D23875 /* CurvedInterpolationDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = E9595DFB1C9973B9004129DA /* CurvedInterpolationDemo.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -266,6 +268,8 @@
 		C3F42A2714D3A75F0044B323 /* CurvedScatterPlot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 2; name = CurvedScatterPlot.m; path = src/plots/CurvedScatterPlot.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		C3F97F1717A9DE2000A52FF2 /* FunctionPlot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FunctionPlot.h; path = src/plots/FunctionPlot.h; sourceTree = "<group>"; };
 		C3F97F1817A9DE2000A52FF2 /* FunctionPlot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = FunctionPlot.m; path = src/plots/FunctionPlot.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		E9595DFA1C9973B9004129DA /* CurvedInterpolationDemo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CurvedInterpolationDemo.h; path = src/plots/CurvedInterpolationDemo.h; sourceTree = "<group>"; };
+		E9595DFB1C9973B9004129DA /* CurvedInterpolationDemo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CurvedInterpolationDemo.m; path = src/plots/CurvedInterpolationDemo.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -396,6 +400,8 @@
 				C35597951437E07800B41DA7 /* ControlChart.m */,
 				C3F42A2614D3A75F0044B323 /* CurvedScatterPlot.h */,
 				C3F42A2714D3A75F0044B323 /* CurvedScatterPlot.m */,
+				E9595DFA1C9973B9004129DA /* CurvedInterpolationDemo.h */,
+				E9595DFB1C9973B9004129DA /* CurvedInterpolationDemo.m */,
 				4F8E1C12129077C200D2035F /* DatePlot.h */,
 				4F8E1C13129077C200D2035F /* DatePlot.m */,
 				C3F34F1312AB2598008FBDC3 /* DonutChart.h */,
@@ -675,6 +681,7 @@
 				C39C4E4113BFE1A900CD9194 /* LabelingPolicyDemo.m in Sources */,
 				C39C4E4413BFE1B400CD9194 /* PlotSpaceDemo.m in Sources */,
 				C354C0D713C7CDBE00DA8822 /* RealTimePlot.m in Sources */,
+				E9595DFC1C9973B9004129DA /* CurvedInterpolationDemo.m in Sources */,
 				C367249313E103910070F47A /* LineCapDemo.m in Sources */,
 				C35597961437E07800B41DA7 /* ControlChart.m in Sources */,
 				C3A31A5614DF782A00734AB7 /* ColoredBarChart.m in Sources */,
@@ -696,6 +703,7 @@
 				C34CB5871BC9B1C1009270A0 /* LabelingPolicyDemo.m in Sources */,
 				C34CB5801BC9B1C1009270A0 /* ControlChart.m in Sources */,
 				C34CB5831BC9B1C1009270A0 /* DonutChart.m in Sources */,
+				E9AB989C1C9A903700D23875 /* CurvedInterpolationDemo.m in Sources */,
 				C34CB5811BC9B1C1009270A0 /* CurvedScatterPlot.m in Sources */,
 				C34CB5861BC9B1C1009270A0 /* ImageDemo.m in Sources */,
 				C34CB5541BC9A889009270A0 /* AppDelegate.m in Sources */,

--- a/examples/CorePlotGallery/src/plots/CurvedInterpolationDemo.h
+++ b/examples/CorePlotGallery/src/plots/CurvedInterpolationDemo.h
@@ -1,0 +1,13 @@
+//
+//  CurvedInterpolationDemo.h
+//  Plot_Gallery
+//
+//  Created by malte on 16/03/16.
+//
+//
+
+#import "PlotItem.h"
+
+@interface CurvedInterpolationDemo : PlotItem<CPTScatterPlotDataSource,CPTPlotSpaceDelegate>
+
+@end

--- a/examples/CorePlotGallery/src/plots/CurvedInterpolationDemo.m
+++ b/examples/CorePlotGallery/src/plots/CurvedInterpolationDemo.m
@@ -1,0 +1,316 @@
+//
+//  CurvedInterpolationDemo.m
+//  Plot_Gallery
+//
+//  Created by malte on 16/03/16.
+//
+//
+
+#import "CurvedInterpolationDemo.h"
+
+static const CGFloat bezierYShift = -1.0;
+static const CGFloat catmullRomUniformPlotYShift = 0.0;
+static const CGFloat catmullRomCentripetalYShift = 1.0;
+static const CGFloat catmullRomChordalYShift = 2.0;
+static const CGFloat hermiteCubicYShift = -2.0;
+
+static NSString * const bezierCurveIdentifier = @"Bezier";
+static NSString * const catmullRomUniformIdentifier = @"Catmull-Rom Uniform";
+static NSString * const catmullRomCentripetalIdentifier = @"Catmull-Rom Centripetal";
+static NSString * const catmullRomChordalIdentifier = @"Catmull-Rom Chordal";
+static NSString * const hermiteCubicIdentifier = @"Hermite Cubic";
+
+@interface CurvedInterpolationDemo()
+
+@property (nonatomic, readwrite, strong) NSArray<NSDictionary<NSString *, NSNumber *> *> *plotData;
+
+
+@end
+
+@implementation CurvedInterpolationDemo
+
+@synthesize plotData = _plotData;
+
+
++(void)load
+{
+    [super registerPlotItem:self];
+}
+
+-(instancetype)init
+{
+    if ( (self = [super init]) ) {
+        self.title   = @"Curved Interpolation Options Demo";
+        self.section = kLinePlots;
+    }
+    
+    return self;
+}
+
+-(void)generateData{
+    if (self.plotData == nil) {
+        
+        NSArray<NSNumber *> * const xValues = @[@0,  @0.1,   @0.2,  @0.5 ,@0.6  ,@0.7   ,@1];
+        NSArray<NSNumber *> * const yValues = @[@(0.5),@0.5,   @(-1), @1   ,@1    ,@0     ,@0.1];
+        
+        if (xValues.count != yValues.count) {
+            [[NSException exceptionWithName:NSInternalInconsistencyException reason:@"invalid const data" userInfo:nil] raise];
+        }
+        NSMutableArray<NSDictionary<NSString*,NSNumber*> *> *generatedData = [NSMutableArray new];
+        for (NSUInteger i = 0; i < xValues.count; i++) {
+            NSNumber *x = xValues[i];
+            NSNumber *y = yValues[i];
+            if (x && y) {
+                [generatedData addObject:@{
+                                     @"x":x,
+                                     @"y":y
+                                     }];
+            }
+        }
+        self.plotData = generatedData;
+    }
+}
+
+-(void)renderInGraphHostingView:(CPTGraphHostingView *)hostingView withTheme:(CPTTheme *)theme animated:(BOOL)animated
+{
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+    CGRect bounds = hostingView.bounds;
+#else
+    CGRect bounds = NSRectToCGRect(hostingView.bounds);
+#endif
+    
+    CPTGraph *graph = [[CPTXYGraph alloc] initWithFrame:bounds];
+    [self addGraph:graph toHostingView:hostingView];
+    [self applyTheme:theme toGraph:graph withDefault:[CPTTheme themeNamed:kCPTDarkGradientTheme]];
+    
+    graph.plotAreaFrame.paddingLeft   += self.titleSize * CPTFloat(2.25);
+    graph.plotAreaFrame.paddingTop    += self.titleSize;
+    graph.plotAreaFrame.paddingRight  += self.titleSize;
+    graph.plotAreaFrame.paddingBottom += self.titleSize;
+    graph.plotAreaFrame.masksToBorder  = NO;
+    
+    // Setup scatter plot space
+    CPTXYPlotSpace *plotSpace = (CPTXYPlotSpace *)graph.defaultPlotSpace;
+    plotSpace.allowsUserInteraction = YES;
+    plotSpace.delegate              = self;
+    
+    // Grid line styles
+    CPTMutableLineStyle *majorGridLineStyle = [CPTMutableLineStyle lineStyle];
+    majorGridLineStyle.lineWidth = 0.75;
+    majorGridLineStyle.lineColor = [[CPTColor colorWithGenericGray:CPTFloat(0.2)] colorWithAlphaComponent:CPTFloat(0.75)];
+    
+    CPTMutableLineStyle *minorGridLineStyle = [CPTMutableLineStyle lineStyle];
+    minorGridLineStyle.lineWidth = 0.25;
+    minorGridLineStyle.lineColor = [[CPTColor whiteColor] colorWithAlphaComponent:CPTFloat(0.1)];
+    
+    CPTMutableLineStyle *redLineStyle = [CPTMutableLineStyle lineStyle];
+    redLineStyle.lineWidth = 10.0;
+    redLineStyle.lineColor = [[CPTColor redColor] colorWithAlphaComponent:0.5];
+    
+    CPTLineCap *lineCap = [CPTLineCap sweptArrowPlotLineCap];
+    lineCap.size = CGSizeMake( self.titleSize * CPTFloat(0.625), self.titleSize * CPTFloat(0.625) );
+    
+    // Axes
+    // Label x axis with a fixed interval policy
+    CPTXYAxisSet *axisSet = (CPTXYAxisSet *)graph.axisSet;
+    CPTXYAxis *x          = axisSet.xAxis;
+    x.majorIntervalLength   = @0.1;
+    x.minorTicksPerInterval = 4;
+    x.majorGridLineStyle    = majorGridLineStyle;
+    x.minorGridLineStyle    = minorGridLineStyle;
+    x.axisConstraints       = [CPTConstraints constraintWithRelativeOffset:0.5];
+    
+    lineCap.lineStyle = x.axisLineStyle;
+    lineCap.fill      = [CPTFill fillWithColor:lineCap.lineStyle.lineColor];
+    x.axisLineCapMax  = lineCap;
+    
+    x.title       = @"X Axis";
+    x.titleOffset = self.titleSize * CPTFloat(1.25);
+    
+    // Label y with an automatic label policy.
+    CPTXYAxis *y = axisSet.yAxis;
+    y.labelingPolicy              = CPTAxisLabelingPolicyAutomatic;
+    y.minorTicksPerInterval       = 4;
+    y.preferredNumberOfMajorTicks = 8;
+    y.majorGridLineStyle          = majorGridLineStyle;
+    y.minorGridLineStyle          = minorGridLineStyle;
+    y.axisConstraints             = [CPTConstraints constraintWithLowerOffset:0.0];
+    y.labelOffset                 = self.titleSize * CPTFloat(0.25);
+    
+    lineCap.lineStyle = y.axisLineStyle;
+    lineCap.fill      = [CPTFill fillWithColor:lineCap.lineStyle.lineColor];
+    y.axisLineCapMax  = lineCap;
+    y.axisLineCapMin  = lineCap;
+    
+    y.title       = @"Y Axis";
+    y.titleOffset = self.titleSize * CPTFloat(1.25);
+    
+    // Set axes
+    graph.axisSet.axes = @[x, y];
+    
+    // Create the plots
+    //Bezier
+    CPTScatterPlot *bezierPlot = [[CPTScatterPlot alloc] initWithFrame:CGRectZero];
+    bezierPlot.identifier = bezierCurveIdentifier;
+    //Catmull-Rom
+    CPTScatterPlot *cmUniformPlot = [[CPTScatterPlot alloc] initWithFrame:CGRectZero];
+    cmUniformPlot.identifier = catmullRomUniformIdentifier;
+    CPTScatterPlot *cmCentripetalPlot = [[CPTScatterPlot alloc] initWithFrame:CGRectZero];
+    cmCentripetalPlot.identifier = catmullRomCentripetalIdentifier;
+    CPTScatterPlot *cmChordalPlot = [[CPTScatterPlot alloc] initWithFrame:CGRectZero];
+    cmChordalPlot.identifier = catmullRomChordalIdentifier;
+    //Hermite Cubic
+    CPTScatterPlot *hermitePlot = [[CPTScatterPlot alloc] initWithFrame:CGRectZero];
+    hermitePlot.identifier = hermiteCubicIdentifier;
+    
+    
+    // set interpolation types
+    bezierPlot.interpolation = cmUniformPlot.interpolation = cmCentripetalPlot.interpolation = cmChordalPlot.interpolation = hermitePlot.interpolation = CPTScatterPlotInterpolationCurved;
+    
+    bezierPlot.curvedInterpolationOption = CPTScatterPlotCurvedInterpolationNormal;
+    cmUniformPlot.curvedInterpolationOption = CPTScatterPlotCurvedInterpolationCatmullRomUniform;
+    cmChordalPlot.curvedInterpolationOption = CPTScatterPlotCurvedInterpolationCatmullRomChordal;
+    cmCentripetalPlot.curvedInterpolationOption = CPTScatterPlotCurvedInterpolationCatmullRomCentripetal;
+    hermitePlot.curvedInterpolationOption = CPTScatterPlotCurvedInterpolationHermiteCubic;
+
+   
+    //style plots
+    CPTMutableLineStyle *lineStyle = [bezierPlot.dataLineStyle mutableCopy];
+    lineStyle.lineWidth              = 2.0;
+    lineStyle.lineColor              = [CPTColor greenColor];
+    
+    bezierPlot.dataLineStyle = lineStyle;
+    
+    lineStyle.lineColor = [CPTColor redColor];
+    cmUniformPlot.dataLineStyle = lineStyle;
+    
+    lineStyle.lineColor = [CPTColor orangeColor];
+    cmCentripetalPlot.dataLineStyle = lineStyle;
+    
+    lineStyle.lineColor = [CPTColor yellowColor];
+    cmChordalPlot.dataLineStyle = lineStyle;
+    
+    lineStyle.lineColor = [CPTColor cyanColor];
+    hermitePlot.dataLineStyle = lineStyle;
+    
+   
+    //set data source and add plots
+    bezierPlot.dataSource = cmUniformPlot.dataSource = cmCentripetalPlot.dataSource = cmChordalPlot.dataSource = hermitePlot.dataSource = self;
+    
+    [graph addPlot:bezierPlot];
+    [graph addPlot:cmUniformPlot];
+    [graph addPlot:cmCentripetalPlot];
+    [graph addPlot:cmChordalPlot];
+    [graph addPlot:hermitePlot];
+
+    
+    // Auto scale the plot space to fit the plot data
+    [plotSpace scaleToFitPlots:[graph allPlots]];
+    CPTMutablePlotRange *xRange = [plotSpace.xRange mutableCopy];
+    CPTMutablePlotRange *yRange = [plotSpace.yRange mutableCopy];
+    
+    // Expand the ranges to put some space around the plot
+    [xRange expandRangeByFactor:@1.2];
+    [yRange expandRangeByFactor:@1.2];
+    plotSpace.xRange = xRange;
+    plotSpace.yRange = yRange;
+    
+    [xRange expandRangeByFactor:@1.025];
+    xRange.location = plotSpace.xRange.location;
+    [yRange expandRangeByFactor:@1.05];
+    x.visibleAxisRange = xRange;
+    y.visibleAxisRange = yRange;
+    
+    [xRange expandRangeByFactor:@3.0];
+    [yRange expandRangeByFactor:@3.0];
+    plotSpace.globalXRange = xRange;
+    plotSpace.globalYRange = yRange;
+    
+    // Add plot symbols
+    CPTMutableLineStyle *symbolLineStyle = [CPTMutableLineStyle lineStyle];
+    symbolLineStyle.lineColor = [[CPTColor blackColor] colorWithAlphaComponent:0.5];
+    CPTPlotSymbol *plotSymbol = [CPTPlotSymbol ellipsePlotSymbol];
+    plotSymbol.fill               = [CPTFill fillWithColor:[[CPTColor blueColor] colorWithAlphaComponent:0.5]];
+    plotSymbol.lineStyle          = symbolLineStyle;
+    plotSymbol.size               = CGSizeMake(5.0, 5.0);
+    bezierPlot.plotSymbol = cmUniformPlot.plotSymbol = cmCentripetalPlot.plotSymbol = cmChordalPlot.plotSymbol = hermitePlot.plotSymbol = plotSymbol;
+    
+    // Add legend
+    graph.legend                 = [CPTLegend legendWithGraph:graph];
+    graph.legend.numberOfRows    = 2;
+    graph.legend.textStyle       = x.titleTextStyle;
+    graph.legend.fill            = [CPTFill fillWithColor:[CPTColor darkGrayColor]];
+    graph.legend.borderLineStyle = x.axisLineStyle;
+    graph.legend.cornerRadius    = 5.0;
+    graph.legendAnchor           = CPTRectAnchorBottom;
+    graph.legendDisplacement     = CGPointMake( 0.0, self.titleSize * CPTFloat(2.0) );
+}
+
+#pragma mark -
+#pragma mark Plot Data Source Methods
+
+-(NSUInteger)numberOfRecordsForPlot:(CPTPlot *)plot
+{
+    return self.plotData.count;
+}
+
+-(id)numberForPlot:(CPTPlot *)plot field:(NSUInteger)fieldEnum recordIndex:(NSUInteger)index
+{
+    NSString *identifier = (NSString *)plot.identifier;
+    if (fieldEnum == CPTScatterPlotFieldX) {
+        return self.plotData[index][@"x"];
+    }
+    else{
+        NSNumber *baseY = self.plotData[index][@"y"];
+        CGFloat shift = 0;
+        if ([identifier isEqualToString:catmullRomUniformIdentifier]) {
+            shift = catmullRomUniformPlotYShift;
+        }
+        else if([identifier isEqualToString:catmullRomCentripetalIdentifier]){
+            shift = catmullRomCentripetalYShift;
+        }
+        else if([identifier isEqualToString:catmullRomChordalIdentifier]){
+            shift = catmullRomChordalYShift;
+        }
+        else if([identifier isEqualToString:hermiteCubicIdentifier]){
+            shift = hermiteCubicYShift;
+        }
+        else if([identifier isEqualToString:bezierCurveIdentifier]){
+            shift = bezierYShift;
+        }
+        return @(baseY.doubleValue + shift);
+    }
+}
+
+#pragma mark -
+#pragma mark Plot Space Delegate Methods
+
+-(CPTPlotRange *)plotSpace:(CPTPlotSpace *)space willChangePlotRangeTo:(CPTPlotRange *)newRange forCoordinate:(CPTCoordinate)coordinate
+{
+    CPTGraph *theGraph    = space.graph;
+    CPTXYAxisSet *axisSet = (CPTXYAxisSet *)theGraph.axisSet;
+    
+    CPTMutablePlotRange *changedRange = [newRange mutableCopy];
+    
+    switch ( coordinate ) {
+        case CPTCoordinateX:
+            [changedRange expandRangeByFactor:@1.025];
+            changedRange.location          = newRange.location;
+            axisSet.xAxis.visibleAxisRange = changedRange;
+            break;
+            
+        case CPTCoordinateY:
+            [changedRange expandRangeByFactor:@1.05];
+            axisSet.yAxis.visibleAxisRange = changedRange;
+            break;
+            
+        default:
+            break;
+    }
+    
+    return newRange;
+}
+
+
+
+@end

--- a/framework/Source/CPTScatterPlot.h
+++ b/framework/Source/CPTScatterPlot.h
@@ -31,7 +31,19 @@ typedef NS_ENUM (NSInteger, CPTScatterPlotInterpolation) {
     CPTScatterPlotInterpolationLinear,    ///< Linear interpolation.
     CPTScatterPlotInterpolationStepped,   ///< Steps beginning at data point.
     CPTScatterPlotInterpolationHistogram, ///< Steps centered at data point.
-    CPTScatterPlotInterpolationCurved     ///< Bezier curve interpolation.
+    CPTScatterPlotInterpolationCurved     ///< Curved interpolation.
+};
+
+/**
+ *  @brief Enumration of scatter plot curved interpolation style options
+ **/
+typedef NS_ENUM(NSInteger, CPTScatterPlotCurvedInterpolationOption){
+    CPTScatterPlotCurvedInterpolationNormal, ///< Standard Curved Interpolation (Bezier Curve)
+    CPTScatterPlotCurvedInterpolationCatmullRomUniform, ///< Catmull-Rom Spline Interpolation with alpha = 0.0.
+    CPTScatterPlotCurvedInterpolationCatmullRomCentripetal, ///< Catmull-Rom Spline Interpolation with alpha = 0.5.
+    CPTScatterPlotCurvedInterpolationCatmullRomChordal, ///< Catmull-Rom Spline Interpolation with alpha = 1.0.
+    CPTScatterPlotCurvedInterpolationCatmullCustomAlpha,///< Catmull-Rom Spline Interpolation with a custom alpha value.
+    CPTScatterPlotCurvedInterpolationHermiteCubic ///< Hermite Cubic Spline Interpolation
 };
 
 /**
@@ -234,6 +246,8 @@ typedef NS_ENUM (NSInteger, CPTScatterPlotHistogramOption) {
 @property (nonatomic, readwrite, strong, nullable) NSNumber *areaBaseValue2;
 @property (nonatomic, readwrite, assign) CPTScatterPlotInterpolation interpolation;
 @property (nonatomic, readwrite, assign) CPTScatterPlotHistogramOption histogramOption;
+@property (nonatomic, readwrite, assign) CPTScatterPlotCurvedInterpolationOption curvedInterpolationOption;
+@property (nonatomic, readwrite, assign) CGFloat curvedInterpolationCustomAlpha;
 /// @}
 
 /// @name Area Fill Bands

--- a/framework/Source/CPTScatterPlot.m
+++ b/framework/Source/CPTScatterPlot.m
@@ -1251,9 +1251,9 @@ NSString *const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; ///< Plot sym
             CGFloat d1_a = pow(d1,alpha);//d1^alpha
             CGFloat d2_a = pow(d2,alpha);//d2^alpha
             CGFloat d3_a = pow(d3,alpha);//d3^alpha
-            CGFloat d1_2a = pow(d1_a,2);//d1^alpha^2 = d1^2*alpha
-            CGFloat d2_2a = pow(d2_a,2);//d2^2alpha
-            CGFloat d3_2a = pow(d3_a,2);
+            CGFloat d1_2a = pow(d1_a,CPTFloat(2));//d1^alpha^2 = d1^2*alpha
+            CGFloat d2_2a = pow(d2_a,CPTFloat(2));//d2^2alpha
+            CGFloat d3_2a = pow(d3_a,CPTFloat(2));
             
             //calculate the control points
             //see : http://www.cemyuksel.com/research/catmullrom_param/catmullrom.pdf under point 3.


### PR DESCRIPTION
I implemented two new interpolation methods for `CPTScatterPlot` with the interpolation `CPTScatterPlotInterpolationCurved`. The beziér interpolation had some weaknesses especially regarding very close points and self-intersection. The Catmull-Rom interpolation fits the curve more tightly and does not produce so much overshoot. Furthermore it has a custom alpha value which allows the user to select the tightness of interpolation and makes it possible to prevent self-intersection alltogether. See [here](http://www.cemyuksel.com/research/catmullrom_param/catmullrom.pdf) for more information on the topic.
I also implemented a hermite cubic interpolation that might allow for someone to implement the monotonic cubic interpolation, which is a feature request.
The pull request passes travis, supports all platforms and I even added a example in the *Plot Gallery* example app.

If there is anything wrong, just hit me up so i can fix it.

~ malte