### PR TITLE
use graph view bounds to render images and gradientes

### DIFF
--- a/framework/Source/CPTLineStyle.m
+++ b/framework/Source/CPTLineStyle.m
@@ -277,6 +277,23 @@
     }
 }
 
+-(void)strokePathInContext:(nonnull CGContextRef)context withBounds:(CGRect)bounds
+{
+    CPTGradient *gradient = self.lineGradient;
+    CPTFill *fill         = self.lineFill;
+    
+    if ( gradient ) {
+        [self strokePathWithGradient:gradient inContext:context];
+    }
+    else if ( fill ) {
+        CGContextReplacePathWithStrokedPath(context);
+        [fill fillPathInContext:context withBounds:bounds];
+    }
+    else {
+        CGContextStrokePath(context);
+    }
+}
+
 /** @brief Stroke a rectangular path in the given graphics context.
  *  Call @link CPTLineStyle::setLineStyleInContext: -setLineStyleInContext: @endlink first to set up the drawing properties.
  *

--- a/framework/Source/CPTScatterPlot.m
+++ b/framework/Source/CPTScatterPlot.m
@@ -923,7 +923,7 @@ NSString *const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; ///< Plot sym
             CGContextBeginPath(context);
             CGContextAddPath(context, dataLinePath);
             [theLineStyle setLineStyleInContext:context];
-            [theLineStyle strokePathInContext:context];
+            [theLineStyle strokePathInContext:context withBounds:self.frame];
             CGPathRelease(dataLinePath);
         }
 

--- a/framework/Source/_CPTFillGradient.h
+++ b/framework/Source/_CPTFillGradient.h
@@ -14,6 +14,7 @@
 /// @{
 -(void)fillRect:(CGRect)rect inContext:(nonnull CGContextRef)context;
 -(void)fillPathInContext:(nonnull CGContextRef)context;
+-(void)fillPathInContext:(nonnull CGContextRef)context withBounds:(CGRect) bounds;
 /// @}
 
 @end

--- a/framework/Source/_CPTFillGradient.m
+++ b/framework/Source/_CPTFillGradient.m
@@ -58,6 +58,11 @@
     [self.fillGradient fillPathInContext:context];
 }
 
+-(void)fillPathInContext:(nonnull CGContextRef)context withBounds:(CGRect) bounds
+{
+    [self.fillGradient fillPathInContext:context withBounds:bounds];
+}
+
 #pragma mark -
 #pragma mark Opacity
 

--- a/framework/Source/_CPTFillImage.h
+++ b/framework/Source/_CPTFillImage.h
@@ -14,6 +14,7 @@
 /// @{
 -(void)fillRect:(CGRect)rect inContext:(nonnull CGContextRef)context;
 -(void)fillPathInContext:(nonnull CGContextRef)context;
+-(void)fillPathInContext:(nonnull CGContextRef)context withBounds:(CGRect) bounds;
 /// @}
 
 @end

--- a/framework/Source/_CPTFillImage.m
+++ b/framework/Source/_CPTFillImage.m
@@ -64,6 +64,21 @@
     CGContextRestoreGState(context);
 }
 
+-(void)fillPathInContext:(nonnull CGContextRef)context withBounds:(CGRect) bounds
+{
+    CGRect pathBounds = CGContextGetPathBoundingBox(context);
+    if (!CGRectIsNull(pathBounds)) {
+    
+        CGContextSaveGState(context);
+        
+        CGContextClip(context);
+        [self.fillImage drawInRect:bounds inContext:context];
+        
+        CGContextRestoreGState(context);
+        
+    }
+}
+
 #pragma mark -
 #pragma mark Opacity
 


### PR DESCRIPTION
use graph view bounds to render images and gradientes, so gradients and images can be used to represent some kind of information (like a gradient showing a range of values).