### PR TITLE
Support Xcode8/iOS10

### DIFF
--- a/framework/Source/CPTCalendarFormatter.m
+++ b/framework/Source/CPTCalendarFormatter.m
@@ -142,7 +142,7 @@
  *  @param coordinateValue The time value.
  *  @return The date string.
  **/
--(nullable NSString *)stringForObjectValue:(nonnull id)coordinateValue
+-(nullable NSString *)stringForObjectValue:(nullable id)coordinateValue
 {
     NSInteger componentIncrement = 0;
 

--- a/framework/Source/CPTTimeFormatter.m
+++ b/framework/Source/CPTTimeFormatter.m
@@ -116,7 +116,7 @@
  *  @param coordinateValue The time value.
  *  @return The date string.
  **/
--(nullable NSString *)stringForObjectValue:(nonnull id)coordinateValue
+-(nullable NSString *)stringForObjectValue:(nullable id)coordinateValue
 {
     NSString *string = nil;
 

--- a/framework/iPhoneOnly/CPTGraphHostingView.m
+++ b/framework/iPhoneOnly/CPTGraphHostingView.m
@@ -230,7 +230,7 @@
     }
 }
 
--(void)touchesCancelled:(nullable NSSet<UITouch *> *)touches withEvent:(nullable UIEvent *)event
+-(void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(nullable UIEvent *)event
 {
     BOOL handled = NO;
 


### PR DESCRIPTION
XCode 8 required to have the same nonnull/nullable api in methods signature 
fix it in stringForObjectValue for formater
and touchesCancelled on host view
I fix it for iOS only as i don't have Mac app to test it on.
hope this help
Thanks
Gal