### PR TITLE
Fix typo in example code ScatterPlotController.swift that prevented y…

### DIFF
--- a/examples/CPTTestApp-iPhone/Classes/ScatterPlotController.swift
+++ b/examples/CPTTestApp-iPhone/Classes/ScatterPlotController.swift
@@ -45,7 +45,7 @@ class ScatterPlotController : UIViewController, CPTScatterPlotDataSource, CPTAxi
             ]
         }
 
-        if let y = axisSet.xAxis {
+        if let y = axisSet.yAxis {
             y.majorIntervalLength   = 0.5
             y.minorTicksPerInterval = 5
             y.orthogonalPosition    = 2.0


### PR DESCRIPTION
Please consider the following issues before submitting a pull request:

-[] Support all platforms (Mac, iOS, and tvOS)
-[] Pass Travis build validation
-[] Include unit tests where appropriate
-[] If adding a new feature, consider including a demo in the *Plot Gallery* example app
… axis from appearing. Change axisSet.xAxis to axisSet.yAxis