### PR TITLE
Solved problem with vDSP functions in -plotRangeForField

### DIFF
--- a/framework/Source/CPTPlot.m
+++ b/framework/Source/CPTPlot.m
@@ -1472,8 +1472,14 @@ CPTPlotBinding const CPTPlotBindingDataLabels = @"dataLabels"; ///< Plot data la
             double min = (double)INFINITY;
             double max = -(double)INFINITY;
 
-            vDSP_minvD(doubles, 1, &min, (vDSP_Length)numberOfSamples);
-            vDSP_maxvD(doubles, 1, &max, (vDSP_Length)numberOfSamples);
+            for (NSUInteger n = 0; n < numberOfSamples; ++n){
+                if (min > doubles[n]){
+                    min = doubles[n];
+                }
+                if (max < doubles[n]){
+                    max = doubles[n];
+                }
+            }
 
             if ( isnan(min) || isnan(max) ) {
                 // vDSP functions may return NAN if any data in the array is NAN


### PR DESCRIPTION
I found a problem wtih the scaling of my Y axis.

It happens only when nil (NaN) values exists and using double precision. It happened only with some very concrete datasets. For example: 
5,5,5,3,3,nil,nil,nil,2,4

It occurs that the used function to guess the max value returned a 4 instead of a 5. I programmed a proof of concept:

```
        double balance[10];
        balance[0] = 5;
        balance[1] = 5;
        balance[2] = 5;
        balance[3] = 3;
        balance[4] = 3;
        balance[5] = NAN;
        balance[6] = NAN;
        balance[7] = NAN;
        balance[8] = 2;
        balance[9] = 4;
        
        double max = -(double)INFINITY;
        vDSP_maxvD(balance, 1, &max, (vDSP_Length)10);
        NSLog(@"With function: %f", max);
        
        
        double C = -INFINITY;
        for (NSUInteger n = 0; n < 10; ++n){
            if (C < balance[n]){
                C = balance[n];
            }
        }
        NSLog(@"With our function: %f", C);
```

and i send the pull request with a patch