### PR TITLE
Fixed pie drawing for case when there is only one segment and we're d…

### DIFF
--- a/framework/Source/CPTPieChart.m
+++ b/framework/Source/CPTPieChart.m
@@ -724,7 +724,7 @@ static const CGFloat colorLookupTable[10][3] =
             angle   += pieSliceValue * pieRange;
             break;
     }
-    return fmod( angle, CPTFloat(2.0 * M_PI) );
+    return isnan(endingAngle) ? angle : fmod(angle, CPTFloat(2.0 * M_PI));
 }
 
 -(void)addSliceToPath:(nonnull CGMutablePathRef)slicePath centerPoint:(CGPoint)center startingAngle:(CGFloat)startingAngle finishingAngle:(CGFloat)finishingAngle


### PR DESCRIPTION
Sorry, no unit tests, but there is a way to reproduce the problem in the demo project this commit is fixing:

We should reduce number of records for PieChart to only 1:

Project: CPTTestApp-iPhone
Class: PieChartController.swift

```
func numberOfRecords(for plot: CPTPlot) -> UInt
{
         return 1
}
```