### PR TITLE
Allow xcode 8 to compile DatePlot on OS X

### DIFF
--- a/examples/DatePlot/DatePlot.xcodeproj/project.pbxproj
+++ b/examples/DatePlot/DatePlot.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 				PRODUCT_NAME = DatePlot;
 				SWIFT_OBJC_BRIDGING_HEADER = "DatePlot-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -446,7 +446,7 @@
 				PRODUCT_NAME = DatePlot;
 				SWIFT_OBJC_BRIDGING_HEADER = "DatePlot-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Set swift version to 3.0 in the DatePlot project so it builds under Xcode 8.3