### PR TITLE
Use self to allocate classes in factory methods

### DIFF
--- a/framework/Source/CPTBarPlot.m
+++ b/framework/Source/CPTBarPlot.m
@@ -170,7 +170,7 @@ CPTBarPlotBinding const CPTBarPlotBindingBarLineStyles = @"barLineStyles"; ///< 
  **/
 +(nonnull instancetype)tubularBarPlotWithColor:(nonnull CPTColor *)color horizontalBars:(BOOL)horizontal
 {
-    CPTBarPlot *barPlot               = [[CPTBarPlot alloc] init];
+    CPTBarPlot *barPlot               = [[self alloc] init];
     CPTMutableLineStyle *barLineStyle = [[CPTMutableLineStyle alloc] init];
 
     barLineStyle.lineWidth = CPTFloat(1.0);

--- a/framework/Source/CPTColor.m
+++ b/framework/Source/CPTColor.m
@@ -41,7 +41,7 @@
 
         CGColorRef clear = CGColorCreate([CPTColorSpace genericRGBSpace].cgColorSpace, values);
 
-        color = [[CPTColor alloc] initWithCGColor:clear];
+        color = [[self alloc] initWithCGColor:clear];
 
         CGColorRelease(clear);
     });
@@ -139,10 +139,10 @@
     static dispatch_once_t onceToken = 0;
 
     dispatch_once(&onceToken, ^{
-        color = [[CPTColor alloc] initWithComponentRed:CPTFloat(1.0)
-                                                 green:CPTFloat(0.0)
-                                                  blue:CPTFloat(0.0)
-                                                 alpha:CPTFloat(1.0)];
+        color = [[self alloc] initWithComponentRed:CPTFloat(1.0)
+                                             green:CPTFloat(0.0)
+                                              blue:CPTFloat(0.0)
+                                             alpha:CPTFloat(1.0)];
     });
 
     return color;
@@ -158,10 +158,10 @@
     static dispatch_once_t onceToken = 0;
 
     dispatch_once(&onceToken, ^{
-        color = [[CPTColor alloc] initWithComponentRed:CPTFloat(0.0)
-                                                 green:CPTFloat(1.0)
-                                                  blue:CPTFloat(0.0)
-                                                 alpha:CPTFloat(1.0)];
+        color = [[self alloc] initWithComponentRed:CPTFloat(0.0)
+                                             green:CPTFloat(1.0)
+                                              blue:CPTFloat(0.0)
+                                             alpha:CPTFloat(1.0)];
     });
 
     return color;
@@ -177,10 +177,10 @@
     static dispatch_once_t onceToken = 0;
 
     dispatch_once(&onceToken, ^{
-        color = [[CPTColor alloc] initWithComponentRed:CPTFloat(0.0)
-                                                 green:CPTFloat(0.0)
-                                                  blue:CPTFloat(1.0)
-                                                 alpha:CPTFloat(1.0)];
+        color = [[self alloc] initWithComponentRed:CPTFloat(0.0)
+                                             green:CPTFloat(0.0)
+                                              blue:CPTFloat(1.0)
+                                             alpha:CPTFloat(1.0)];
     });
 
     return color;
@@ -196,10 +196,10 @@
     static dispatch_once_t onceToken = 0;
 
     dispatch_once(&onceToken, ^{
-        color = [[CPTColor alloc] initWithComponentRed:CPTFloat(0.0)
-                                                 green:CPTFloat(1.0)
-                                                  blue:CPTFloat(1.0)
-                                                 alpha:CPTFloat(1.0)];
+        color = [[self alloc] initWithComponentRed:CPTFloat(0.0)
+                                             green:CPTFloat(1.0)
+                                              blue:CPTFloat(1.0)
+                                             alpha:CPTFloat(1.0)];
     });
 
     return color;
@@ -215,7 +215,7 @@
     static dispatch_once_t onceToken = 0;
 
     dispatch_once(&onceToken, ^{
-        color = [[CPTColor alloc] initWithComponentRed:CPTFloat(1.0) green:CPTFloat(1.0) blue:CPTFloat(0.0) alpha:CPTFloat(1.0)];
+        color = [[self alloc] initWithComponentRed:CPTFloat(1.0) green:CPTFloat(1.0) blue:CPTFloat(0.0) alpha:CPTFloat(1.0)];
     });
 
     return color;
@@ -230,7 +230,7 @@
     static CPTColor *color = nil;
 
     if ( nil == color ) {
-        color = [[CPTColor alloc] initWithComponentRed:CPTFloat(1.0) green:CPTFloat(0.0) blue:CPTFloat(1.0) alpha:CPTFloat(1.0)];
+        color = [[self alloc] initWithComponentRed:CPTFloat(1.0) green:CPTFloat(0.0) blue:CPTFloat(1.0) alpha:CPTFloat(1.0)];
     }
     return color;
 }
@@ -245,7 +245,7 @@
     static dispatch_once_t onceToken = 0;
 
     dispatch_once(&onceToken, ^{
-        color = [[CPTColor alloc] initWithComponentRed:CPTFloat(1.0) green:CPTFloat(0.5) blue:CPTFloat(0.0) alpha:CPTFloat(1.0)];
+        color = [[self alloc] initWithComponentRed:CPTFloat(1.0) green:CPTFloat(0.5) blue:CPTFloat(0.0) alpha:CPTFloat(1.0)];
     });
 
     return color;
@@ -261,7 +261,7 @@
     static dispatch_once_t onceToken = 0;
 
     dispatch_once(&onceToken, ^{
-        color = [[CPTColor alloc] initWithComponentRed:CPTFloat(0.5) green:CPTFloat(0.0) blue:CPTFloat(0.5) alpha:CPTFloat(1.0)];
+        color = [[self alloc] initWithComponentRed:CPTFloat(0.5) green:CPTFloat(0.0) blue:CPTFloat(0.5) alpha:CPTFloat(1.0)];
     });
 
     return color;
@@ -277,7 +277,7 @@
     static dispatch_once_t onceToken = 0;
 
     dispatch_once(&onceToken, ^{
-        color = [[CPTColor alloc] initWithComponentRed:CPTFloat(0.6) green:CPTFloat(0.4) blue:CPTFloat(0.2) alpha:CPTFloat(1.0)];
+        color = [[self alloc] initWithComponentRed:CPTFloat(0.6) green:CPTFloat(0.4) blue:CPTFloat(0.2) alpha:CPTFloat(1.0)];
     });
 
     return color;
@@ -289,7 +289,7 @@
  **/
 +(nonnull instancetype)colorWithCGColor:(nonnull CGColorRef)newCGColor
 {
-    return [[CPTColor alloc] initWithCGColor:newCGColor];
+    return [[self alloc] initWithCGColor:newCGColor];
 }
 
 /** @brief Creates and returns a new CPTColor instance initialized with the provided RGBA color components.
@@ -301,7 +301,7 @@
  **/
 +(nonnull instancetype)colorWithComponentRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha
 {
-    return [[CPTColor alloc] initWithComponentRed:red green:green blue:blue alpha:alpha];
+    return [[self alloc] initWithComponentRed:red green:green blue:blue alpha:alpha];
 }
 
 /** @brief Creates and returns a new CPTColor instance initialized with the provided gray level.
@@ -312,7 +312,7 @@
 {
     CGFloat values[4]   = { gray, gray, gray, CPTFloat(1.0) };
     CGColorRef colorRef = CGColorCreate([CPTColorSpace genericRGBSpace].cgColorSpace, values);
-    CPTColor *color     = [[CPTColor alloc] initWithCGColor:colorRef];
+    CPTColor *color     = [[self alloc] initWithCGColor:colorRef];
 
     CGColorRelease(colorRef);
     return color;
@@ -382,7 +382,7 @@
 -(nonnull instancetype)colorWithAlphaComponent:(CGFloat)alpha
 {
     CGColorRef newCGColor = CGColorCreateCopyWithAlpha(self.cgColor, alpha);
-    CPTColor *newColor    = [CPTColor colorWithCGColor:newCGColor];
+    CPTColor *newColor    = [[self class] colorWithCGColor:newCGColor];
 
     CGColorRelease(newCGColor);
     return newColor;

--- a/framework/Source/CPTColorSpace.m
+++ b/framework/Source/CPTColorSpace.m
@@ -37,7 +37,7 @@
 #else
         cgSpace = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
 #endif
-        space = [[CPTColorSpace alloc] initWithCGColorSpace:cgSpace];
+        space = [[self alloc] initWithCGColorSpace:cgSpace];
         CGColorSpaceRelease(cgSpace);
     });
 

--- a/framework/Source/CPTLimitBand.m
+++ b/framework/Source/CPTLimitBand.m
@@ -28,7 +28,7 @@
  **/
 +(nonnull instancetype)limitBandWithRange:(nullable CPTPlotRange *)newRange fill:(nullable CPTFill *)newFill
 {
-    return [[CPTLimitBand alloc] initWithRange:newRange fill:newFill];
+    return [[self alloc] initWithRange:newRange fill:newFill];
 }
 
 /** @brief Initializes a newly allocated CPTLimitBand object with the provided range and fill.


### PR DESCRIPTION
Several classes had factory methods that had the name of the class hardcoded, instead of using `self`.  This made using the factory method from a subclass impossible.  i.e. I subclassed `CPTBarPlot`, but couldn't use `tubularBarPlotWithColor:horizontalBars:` because it used `[CPTBarPlot alloc] init]` instead of `[[self alloc] init]`.

Although I only needed `CPTBarPlot`, I went ahead and searched for other factory methods that were using a fixed class name as well.  Most were already using `self`, so this pull request only updates 4 classes.

Note: there were a couple of classes that looked like they were using factory methods to create specific subclasses in a class-cluster, so I did not change those.  I only updated the factory methods that were creating the same type of class they were a member of.

these changes are relatively simple and should be platform agnostic.