### PR TITLE
Xcode 9, Carthage & Core Plot compatibility

### DIFF
--- a/framework/CorePlot.xcodeproj/xcshareddata/xcschemes/CorePlot Mac.xcscheme
+++ b/framework/CorePlot.xcodeproj/xcshareddata/xcschemes/CorePlot Mac.xcscheme
@@ -27,8 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/framework/CorePlot.xcodeproj/xcshareddata/xcschemes/CorePlot iOS.xcscheme
+++ b/framework/CorePlot.xcodeproj/xcshareddata/xcschemes/CorePlot iOS.xcscheme
@@ -40,8 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -70,6 +70,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/framework/CorePlot.xcodeproj/xcshareddata/xcschemes/CorePlot tvOS.xcscheme
+++ b/framework/CorePlot.xcodeproj/xcshareddata/xcschemes/CorePlot tvOS.xcscheme
@@ -40,8 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -70,6 +70,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/framework/CorePlot.xcodeproj/xcshareddata/xcschemes/CorePlot-CocoaTouch.xcscheme
+++ b/framework/CorePlot.xcodeproj/xcshareddata/xcschemes/CorePlot-CocoaTouch.xcscheme
@@ -40,8 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -70,6 +70,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
Please consider the following issues before submitting a pull request:

-[x] Support all platforms (Mac, iOS, and tvOS)
-[x] Pass Travis build validation
-[x] Include unit tests where appropriate
-[x] If adding a new feature, consider including a demo in the *Plot Gallery* example app

I've been working with Xcode 9 and uploading builds to TestFlight for testing, and ran into a new issue as soon as I added Core Plot as a dependency to my project using Carthage. It seems that in Xcode 9, if the Test action of a scheme has "Gather coverage data" enabled, it will include that profiling instrumentation in the build framework that Carthage generates. Unfortunately, iTunes Connect will reject builds that include this instrumentation which means in it's current state people using Carthage won't be able to submit their apps using Core Plot.

The Carthage team has decided they are unable to fix this issue on their side (see Carthage/Carthage#2056) and Apple has confirmed this is expected behaviour for Xcode 9 (https://forums.developer.apple.com/thread/81893).

My suggestion would be to disable the Gather coverage data option in the scheme's test action - I understand this is probably a difficult choice to make as having that coverage data is useful when testing code, but I imagine this will become a more common issue as people upgrade over time.

I've turned the setting off here for the iOS, macOS and tvOS targets, as I believe they will all fail when uploaded to iTunes Connect.