### PR TITLE
MallocHunter 2018: Convert remaining`malloc()` calls to `calloc()`.

### DIFF
--- a/framework/Source/CPTAnimation.m
+++ b/framework/Source/CPTAnimation.m
@@ -425,7 +425,7 @@ typedef NSMutableArray<CPTAnimationOperation *> CPTMutableAnimationArray;
                 invocation.target   = boundObject;
                 invocation.selector = boundSetter;
 
-                void *buffer = malloc(bufferSize);
+                void *buffer = calloc(1, bufferSize);
                 [value getValue:buffer];
                 [invocation setArgument:buffer atIndex:2];
                 free(buffer);

--- a/framework/Source/CPTColor.m
+++ b/framework/Source/CPTColor.m
@@ -435,7 +435,7 @@
 
         size_t numberOfComponents = (size_t)[coder decodeInt64ForKey:@"CPTColor.numberOfComponents"];
 
-        CGFloat *colorComponents = malloc(numberOfComponents * sizeof(CGFloat) );
+        CGFloat *colorComponents = calloc(numberOfComponents, sizeof(CGFloat));
 
         for ( size_t i = 0; i < numberOfComponents; i++ ) {
             NSString *newKey = [[NSString alloc] initWithFormat:@"CPTColor.component[%zu]", i];

--- a/framework/Source/CPTGradient.m
+++ b/framework/Source/CPTGradient.m
@@ -1167,7 +1167,7 @@ static void CPTResolveHSV(CGFloat *__nonnull color1, CGFloat *__nonnull color2);
 
     if ( (curElement == NULL) || (newElement->position < curElement->position) ) {
         CPTGradientElement *tmpNext        = curElement;
-        CPTGradientElement *newElementList = malloc(sizeof(CPTGradientElement) );
+        CPTGradientElement *newElementList = calloc(1, sizeof(CPTGradientElement));
         if ( newElementList ) {
             *newElementList             = *newElement;
             newElementList->nextElement = tmpNext;
@@ -1182,7 +1182,7 @@ static void CPTResolveHSV(CGFloat *__nonnull color1, CGFloat *__nonnull color2);
         }
 
         CPTGradientElement *tmpNext = curElement->nextElement;
-        curElement->nextElement              = malloc(sizeof(CPTGradientElement) );
+        curElement->nextElement              = calloc(1, sizeof(CPTGradientElement));
         *(curElement->nextElement)           = *newElement;
         curElement->nextElement->nextElement = tmpNext;
     }

--- a/framework/Source/CPTLegend.m
+++ b/framework/Source/CPTLegend.m
@@ -555,8 +555,8 @@ CPTLegendNotification const CPTLegendNeedsReloadEntriesForPlotNotification = @"C
     // calculate column positions
     CPTNumberArray *computedColumnWidths = self.columnWidthsThatFit;
     NSUInteger columnCount               = computedColumnWidths.count;
-    CGFloat *actualColumnWidths          = malloc(sizeof(CGFloat) * columnCount);
-    CGFloat *columnPositions             = malloc(sizeof(CGFloat) * columnCount);
+    CGFloat *actualColumnWidths          = calloc(columnCount, sizeof(CGFloat));
+    CGFloat *columnPositions             = calloc(columnCount, sizeof(CGFloat));
     columnPositions[0] = self.paddingLeft;
     CGFloat theOffset       = self.titleOffset;
     CGSize theSwatchSize    = self.swatchSize;
@@ -579,8 +579,8 @@ CPTLegendNotification const CPTLegendNeedsReloadEntriesForPlotNotification = @"C
     // calculate row positions
     CPTNumberArray *computedRowHeights = self.rowHeightsThatFit;
     NSUInteger rowCount                = computedRowHeights.count;
-    CGFloat *actualRowHeights          = malloc(sizeof(CGFloat) * rowCount);
-    CGFloat *rowPositions              = malloc(sizeof(CGFloat) * rowCount);
+    CGFloat *actualRowHeights          = calloc(rowCount, sizeof(CGFloat));
+    CGFloat *rowPositions              = calloc(rowCount, sizeof(CGFloat));
     rowPositions[rowCount - 1] = self.paddingBottom;
     CGFloat theRowMargin  = self.rowMargin;
     CGFloat lastRowHeight = 0.0;

--- a/framework/Source/CPTPlotArea.m
+++ b/framework/Source/CPTPlotArea.m
@@ -162,7 +162,7 @@ static const size_t kCPTNumberOfLayers = 6; // number of primary layers to arran
         fill               = nil;
         touchedPoint       = CPTPointMake(NAN, NAN);
         topDownLayerOrder  = nil;
-        bottomUpLayerOrder = malloc(kCPTNumberOfLayers * sizeof(CPTGraphLayerType) );
+        bottomUpLayerOrder = calloc(kCPTNumberOfLayers, sizeof(CPTGraphLayerType));
         [self updateLayerOrder];
 
         CPTPlotGroup *newPlotGroup = [[CPTPlotGroup alloc] initWithFrame:newFrame];
@@ -195,8 +195,8 @@ static const size_t kCPTNumberOfLayers = 6; // number of primary layers to arran
         fill               = theLayer->fill;
         touchedPoint       = theLayer->touchedPoint;
         topDownLayerOrder  = theLayer->topDownLayerOrder;
-        bottomUpLayerOrder = malloc(kCPTNumberOfLayers * sizeof(CPTGraphLayerType) );
-        memcpy(bottomUpLayerOrder, theLayer->bottomUpLayerOrder, kCPTNumberOfLayers * sizeof(CPTGraphLayerType) );
+        bottomUpLayerOrder = calloc(kCPTNumberOfLayers, sizeof(CPTGraphLayerType));
+        memcpy(bottomUpLayerOrder, theLayer->bottomUpLayerOrder, kCPTNumberOfLayers * sizeof(CPTGraphLayerType));
         widthDecimal  = theLayer->widthDecimal;
         heightDecimal = theLayer->heightDecimal;
     }
@@ -256,7 +256,7 @@ static const size_t kCPTNumberOfLayers = 6; // number of primary layers to arran
         topDownLayerOrder = [coder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSNumber class]]]
                                                   forKey:@"CPTPlotArea.topDownLayerOrder"];
 
-        bottomUpLayerOrder = malloc(kCPTNumberOfLayers * sizeof(CPTGraphLayerType) );
+        bottomUpLayerOrder = calloc(kCPTNumberOfLayers, sizeof(CPTGraphLayerType));
         [self updateLayerOrder];
 
         touchedPoint = CPTPointMake(NAN, NAN);

--- a/framework/Source/CPTPlotSpaceAnnotation.m
+++ b/framework/Source/CPTPlotSpaceAnnotation.m
@@ -196,7 +196,7 @@
 
         self.anchorCount = anchorPlotPoint.count;
 
-        NSDecimal *decimalPoint = malloc(sizeof(NSDecimal) * self.anchorCount);
+        NSDecimal *decimalPoint = calloc(self.anchorCount, sizeof(NSDecimal));
         for ( NSUInteger i = 0; i < self.anchorCount; i++ ) {
             decimalPoint[i] = anchorPlotPoint[i].decimalValue;
         }

--- a/framework/Source/CPTRangePlot.m
+++ b/framework/Source/CPTRangePlot.m
@@ -274,9 +274,9 @@ typedef struct CGPointError CGPointError;
         }
     }
     else {
-        CPTPlotRangeComparisonResult *xRangeFlags = malloc(dataCount * sizeof(CPTPlotRangeComparisonResult) );
-        CPTPlotRangeComparisonResult *yRangeFlags = malloc(dataCount * sizeof(CPTPlotRangeComparisonResult) );
-        BOOL *nanFlags                            = malloc(dataCount * sizeof(BOOL) );
+        CPTPlotRangeComparisonResult *xRangeFlags = calloc(dataCount, sizeof(CPTPlotRangeComparisonResult));
+        CPTPlotRangeComparisonResult *yRangeFlags = calloc(dataCount, sizeof(CPTPlotRangeComparisonResult));
+        BOOL                         *nanFlags    = calloc(dataCount, sizeof(BOOL));
 
         CPTPlotRange *xRange = xyPlotSpace.xRange;
         CPTPlotRange *yRange = xyPlotSpace.yRange;
@@ -1048,8 +1048,8 @@ typedef struct CGPointError CGPointError;
 -(NSUInteger)dataIndexFromInteractionPoint:(CGPoint)point
 {
     NSUInteger dataCount     = self.cachedDataCount;
-    CGPointError *viewPoints = calloc(dataCount, sizeof(CGPointError) );
-    BOOL *drawPointFlags     = malloc(dataCount * sizeof(BOOL) );
+    CGPointError *viewPoints = calloc(dataCount, sizeof(CGPointError));
+    BOOL *drawPointFlags     = calloc(dataCount, sizeof(BOOL));
 
     [self calculatePointsToDraw:drawPointFlags numberOfPoints:dataCount forPlotSpace:(id)self.plotSpace includeVisiblePointsOnly:YES];
     [self calculateViewPoints:viewPoints withDrawPointFlags:drawPointFlags numberOfPoints:dataCount];

--- a/framework/Source/CPTScatterPlot.m
+++ b/framework/Source/CPTScatterPlot.m
@@ -483,9 +483,9 @@ CPTScatterPlotBinding const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; /
         }
     }
     else {
-        CPTPlotRangeComparisonResult *xRangeFlags = malloc(dataCount * sizeof(CPTPlotRangeComparisonResult) );
-        CPTPlotRangeComparisonResult *yRangeFlags = malloc(dataCount * sizeof(CPTPlotRangeComparisonResult) );
-        BOOL *nanFlags                            = malloc(dataCount * sizeof(BOOL) );
+        CPTPlotRangeComparisonResult *xRangeFlags = calloc(dataCount, sizeof(CPTPlotRangeComparisonResult));
+        CPTPlotRangeComparisonResult *yRangeFlags = calloc(dataCount, sizeof(CPTPlotRangeComparisonResult));
+        BOOL                         *nanFlags    = calloc(dataCount, sizeof(BOOL));
 
         CPTPlotRange *xRange = xyPlotSpace.xRange;
         CPTPlotRange *yRange = xyPlotSpace.yRange;
@@ -804,8 +804,8 @@ CPTScatterPlotBinding const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; /
     [super renderAsVectorInContext:context];
 
     // Calculate view points, and align to user space
-    CGPoint *viewPoints  = malloc(dataCount * sizeof(CGPoint) );
-    BOOL *drawPointFlags = malloc(dataCount * sizeof(BOOL) );
+    CGPoint *viewPoints  = calloc(dataCount, sizeof(CGPoint));
+    BOOL *drawPointFlags = calloc(dataCount, sizeof(BOOL));
 
     CPTXYPlotSpace *thePlotSpace = (CPTXYPlotSpace *)self.plotSpace;
     [self calculatePointsToDraw:drawPointFlags forPlotSpace:thePlotSpace includeVisiblePointsOnly:NO numberOfPoints:dataCount];
@@ -1484,10 +1484,10 @@ CPTScatterPlotBinding const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; /
         NSUInteger n = indexRange.length - 1;
 
         // rhs vector
-        CGPoint *a = malloc(n * sizeof(CGPoint) );
-        CGPoint *b = malloc(n * sizeof(CGPoint) );
-        CGPoint *c = malloc(n * sizeof(CGPoint) );
-        CGPoint *r = malloc(n * sizeof(CGPoint) );
+        CGPoint *a = calloc(n, sizeof(CGPoint));
+        CGPoint *b = calloc(n, sizeof(CGPoint));
+        CGPoint *c = calloc(n, sizeof(CGPoint));
+        CGPoint *r = calloc(n, sizeof(CGPoint));
 
         // left most segment
         a[0] = CGPointZero;
@@ -1636,8 +1636,8 @@ CPTScatterPlotBinding const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; /
     }
 
     // Calculate view points
-    CGPoint *viewPoints  = malloc(dataCount * sizeof(CGPoint) );
-    BOOL *drawPointFlags = malloc(dataCount * sizeof(BOOL) );
+    CGPoint *viewPoints  = calloc(dataCount, sizeof(CGPoint));
+    BOOL *drawPointFlags = calloc(dataCount, sizeof(BOOL));
 
     for ( NSUInteger i = 0; i < dataCount; i++ ) {
         drawPointFlags[i] = YES;
@@ -2137,8 +2137,8 @@ CPTScatterPlotBinding const CPTScatterPlotBindingPlotSymbols = @"plotSymbols"; /
     NSUInteger dataCount     = self.cachedDataCount;
 
     if ( theGraph && thePlotArea && !self.hidden && dataCount ) {
-        CGPoint *viewPoints  = malloc(dataCount * sizeof(CGPoint) );
-        BOOL *drawPointFlags = malloc(dataCount * sizeof(BOOL) );
+        CGPoint *viewPoints  = calloc(dataCount, sizeof(CGPoint));
+        BOOL *drawPointFlags = calloc(dataCount, sizeof(BOOL));
 
         CPTXYPlotSpace *thePlotSpace = (CPTXYPlotSpace *)self.plotSpace;
         [self calculatePointsToDraw:drawPointFlags forPlotSpace:thePlotSpace includeVisiblePointsOnly:NO numberOfPoints:dataCount];

--- a/framework/Source/CPTScatterPlotTests.m
+++ b/framework/Source/CPTScatterPlotTests.m
@@ -42,7 +42,7 @@
 {
     CPTNumberArray *inRangeValues = @[@0.1, @0.2, @0.15, @0.6, @0.9];
 
-    BOOL *drawFlags = malloc(sizeof(BOOL) * inRangeValues.count);
+    BOOL *drawFlags = calloc(inRangeValues.count, sizeof(BOOL));
 
     CPTXYPlotSpace *thePlotSpace = self.plotSpace;
 
@@ -60,7 +60,7 @@
 {
     CPTNumberArray *inRangeValues = @[@0.1, @0.2, @0.15, @0.6, @0.9];
 
-    BOOL *drawFlags = malloc(sizeof(BOOL) * inRangeValues.count);
+    BOOL *drawFlags = calloc(inRangeValues.count, sizeof(BOOL));
 
     CPTXYPlotSpace *thePlotSpace = self.plotSpace;
 
@@ -78,7 +78,7 @@
 {
     CPTNumberArray *inRangeValues = @[@(-0.1), @(-0.2), @(-0.15), @(-0.6), @(-0.9)];
 
-    BOOL *drawFlags = malloc(sizeof(BOOL) * inRangeValues.count);
+    BOOL *drawFlags = calloc(inRangeValues.count, sizeof(BOOL));
 
     CPTXYPlotSpace *thePlotSpace = self.plotSpace;
 
@@ -96,7 +96,7 @@
 {
     CPTNumberArray *inRangeValues = @[@(-0.1), @(-0.2), @(-0.15), @(-0.6), @(-0.9)];
 
-    BOOL *drawFlags = malloc(sizeof(BOOL) * inRangeValues.count);
+    BOOL *drawFlags = calloc(inRangeValues.count, sizeof(BOOL));
 
     CPTXYPlotSpace *thePlotSpace = self.plotSpace;
 
@@ -114,7 +114,7 @@
 {
     CPTNumberArray *inRangeValues = @[@(-0.1), @2, @(-0.15), @3, @(-0.9)];
 
-    BOOL *drawFlags = malloc(sizeof(BOOL) * inRangeValues.count);
+    BOOL *drawFlags = calloc(inRangeValues.count, sizeof(BOOL));
 
     CPTXYPlotSpace *thePlotSpace = self.plotSpace;
 
@@ -132,7 +132,7 @@
 {
     CPTNumberArray *inRangeValues = @[@(-0.1), @2, @(-0.15), @3, @(-0.9)];
 
-    BOOL *drawFlags = malloc(sizeof(BOOL) * inRangeValues.count);
+    BOOL *drawFlags = calloc(inRangeValues.count, sizeof(BOOL));
 
     CPTXYPlotSpace *thePlotSpace = self.plotSpace;
 
@@ -151,7 +151,7 @@
     CPTNumberArray *inRangeValues = @[@(-0.1), @0.1, @0.2, @1.2, @1.5];
     BOOL expected[5]              = { YES, YES, YES, YES, NO };
 
-    BOOL *drawFlags = malloc(sizeof(BOOL) * inRangeValues.count);
+    BOOL *drawFlags = calloc(inRangeValues.count, sizeof(BOOL));
 
     CPTXYPlotSpace *thePlotSpace = self.plotSpace;
 
@@ -173,7 +173,7 @@
 {
     CPTNumberArray *inRangeValues = @[@(-0.1), @0.1, @0.2, @1.2, @1.5];
 
-    BOOL *drawFlags = malloc(sizeof(BOOL) * inRangeValues.count);
+    BOOL *drawFlags = calloc(inRangeValues.count, sizeof(BOOL));
 
     CPTXYPlotSpace *thePlotSpace = self.plotSpace;
 
@@ -196,8 +196,8 @@
 {
     CPTNumberArray *inRangeValues = @[@(-0.1), @1.1, @0.9, @(-0.1), @(-0.2)];
 
-    BOOL *drawFlags = malloc(sizeof(BOOL) * inRangeValues.count);
-    BOOL *expected  = malloc(sizeof(BOOL) * inRangeValues.count);
+    BOOL *drawFlags = calloc(inRangeValues.count, sizeof(BOOL));
+    BOOL *expected  = calloc(inRangeValues.count, sizeof(BOOL));
 
     for ( NSUInteger i = 0; i < inRangeValues.count - 1; i++ ) {
         expected[i] = YES;
@@ -226,7 +226,7 @@
 {
     CPTNumberArray *inRangeValues = @[@(-0.1), @1.1, @0.9, @(-0.1), @(-0.2)];
 
-    BOOL *drawFlags = malloc(sizeof(BOOL) * inRangeValues.count);
+    BOOL *drawFlags = calloc(inRangeValues.count, sizeof(BOOL));
 
     CPTXYPlotSpace *thePlotSpace = self.plotSpace;
 

--- a/framework/Source/NSCoderExtensions.m
+++ b/framework/Source/NSCoderExtensions.m
@@ -454,7 +454,7 @@ void CPTPathApplierFunc(void *__nullable info, const CGPathElement *__nonnull el
 
     CGFloat *decodeArray = NULL;
     if ( numberOfComponents ) {
-        decodeArray = malloc(numberOfComponents * 2 * sizeof(CGFloat) );
+        decodeArray = calloc((numberOfComponents * 2), sizeof(CGFloat));
 
         for ( size_t i = 0; i < numberOfComponents; i++ ) {
             newKey             = [[NSString alloc] initWithFormat:@"%@.decode[%zu].lower", key, i];


### PR DESCRIPTION
For certain SDLC process flows, a developer can experience warnings and release hold-ups if any code in the stream contains a call to `malloc()`.  This pull request finds the few remaining instances throughout the CorePlot project, and directly converts them to `calloc()` statements, allowing CorePlot to continue to be used in such situations.