### PR TITLE
Fix name collision in CPTFunctionDataSource

### DIFF
--- a/framework/Source/CPTFunctionDataSource.h
+++ b/framework/Source/CPTFunctionDataSource.h
@@ -23,16 +23,16 @@ typedef double (^CPTDataSourceBlock)(double);
 @property (nonatomic, readwrite) CGFloat resolution;
 @property (nonatomic, readwrite, strong, nullable) CPTPlotRange *dataRange;
 
-/// @name Factory Methods
-/// @{
-+(nonnull instancetype)dataSourceForPlot:(nonnull CPTPlot *)plot withFunction:(nonnull CPTDataSourceFunction)function;
-+(nonnull instancetype)dataSourceForPlot:(nonnull CPTPlot *)plot withBlock:(nonnull CPTDataSourceBlock)block;
+ /// @name Factory Methods
+  /// @{		  /// @{
++(nonnull instancetype)dataSourceForPlot:(nonnull CPTPlot *)plot withFunction:(nonnull CPTDataSourceFunction)function NS_SWIFT_NAME(init(for:withFunction));
++(nonnull instancetype)dataSourceForPlot:(nonnull CPTPlot *)plot withBlock:(nonnull CPTDataSourceBlock)block NS_SWIFT_NAME(init(for:withBlock));
 /// @}
-
+  		  
 /// @name Initialization
 /// @{
--(nonnull instancetype)initForPlot:(nonnull CPTPlot *)plot withFunction:(nonnull CPTDataSourceFunction)function;
--(nonnull instancetype)initForPlot:(nonnull CPTPlot *)plot withBlock:(nonnull CPTDataSourceBlock)block;
+-(nonnull instancetype)initForPlot:(nonnull CPTPlot *)plot withFunction:(nonnull CPTDataSourceFunction)function NS_SWIFT_NAME(init(forPlot:withFunction));
+-(nonnull instancetype)initForPlot:(nonnull CPTPlot *)plot withBlock:(nonnull CPTDataSourceBlock)block NS_SWIFT_NAME(init(forPlot:withBlock));
 /// @}
 
 @end

--- a/framework/Source/CPTFunctionDataSource.h
+++ b/framework/Source/CPTFunctionDataSource.h
@@ -25,14 +25,14 @@ typedef double (^CPTDataSourceBlock)(double);
 
  /// @name Factory Methods
   /// @{		  /// @{
-+(nonnull instancetype)dataSourceForPlot:(nonnull CPTPlot *)plot withFunction:(nonnull CPTDataSourceFunction)function NS_SWIFT_NAME(init(for:withFunction));
-+(nonnull instancetype)dataSourceForPlot:(nonnull CPTPlot *)plot withBlock:(nonnull CPTDataSourceBlock)block NS_SWIFT_NAME(init(for:withBlock));
++(nonnull instancetype)dataSourceForPlot:(nonnull CPTPlot *)plot withFunction:(nonnull CPTDataSourceFunction)function NS_SWIFT_NAME(init(for:withFunction:));
++(nonnull instancetype)dataSourceForPlot:(nonnull CPTPlot *)plot withBlock:(nonnull CPTDataSourceBlock)block NS_SWIFT_NAME(init(for:withBlock:));
 /// @}
   		  
 /// @name Initialization
 /// @{
--(nonnull instancetype)initForPlot:(nonnull CPTPlot *)plot withFunction:(nonnull CPTDataSourceFunction)function NS_SWIFT_NAME(init(forPlot:withFunction));
--(nonnull instancetype)initForPlot:(nonnull CPTPlot *)plot withBlock:(nonnull CPTDataSourceBlock)block NS_SWIFT_NAME(init(forPlot:withBlock));
+-(nonnull instancetype)initForPlot:(nonnull CPTPlot *)plot withFunction:(nonnull CPTDataSourceFunction)function NS_SWIFT_NAME(init(forPlot:withFunction:));
+-(nonnull instancetype)initForPlot:(nonnull CPTPlot *)plot withBlock:(nonnull CPTDataSourceBlock)block NS_SWIFT_NAME(init(forPlot:withBlock:));
 /// @}
 
 @end


### PR DESCRIPTION
This fixes issue #372 by adding different NS_SWIFT_NAME for :

Factory methods : init(for:withFunction/Block:)
Initializers : init(forPlot:withFunction/Block:)
I don't know if this is an ideal situation but it does the trick and prevent the name collision.

This collision was caused by swift which converts convenience class methods to inits.