### PR TITLE
Support creating CPTColor with NSColor to support dynamic system colors and catalog colors

### DIFF
--- a/framework/MacOnly/CPTPlatformSpecificCategories.m
+++ b/framework/MacOnly/CPTPlatformSpecificCategories.m
@@ -66,22 +66,6 @@
 
 @end
 
-#pragma mark - CPTColor
-
-@implementation CPTColor(CPTPlatformSpecificColorExtensions)
-
-/** @property nsColor
- *  @brief Gets the color value as an NSColor.
- **/
-@dynamic nsColor;
-
--(nonnull NSColor *)nsColor
-{
-    return [NSColor colorWithCIColor:[CIColor colorWithCGColor:self.cgColor]];
-}
-
-@end
-
 #pragma mark - NSAttributedString
 
 @implementation NSAttributedString(CPTPlatformSpecificAttributedStringExtensions)

--- a/framework/Source/CPTColor.h
+++ b/framework/Source/CPTColor.h
@@ -3,6 +3,10 @@
 @property (nonatomic, readonly, nonnull) CGColorRef cgColor;
 @property (nonatomic, readonly, getter = isOpaque) BOOL opaque;
 
+#if TARGET_OS_OSX
+@property (nonatomic, readonly, nonnull) NSColor *nsColor;
+#endif
+
 /// @name Factory Methods
 /// @{
 +(nonnull instancetype)clearColor;
@@ -24,6 +28,11 @@
 +(nonnull instancetype)colorWithCGColor:(nonnull CGColorRef)newCGColor;
 +(nonnull instancetype)colorWithComponentRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
 +(nonnull instancetype)colorWithGenericGray:(CGFloat)gray;
+
+#if TARGET_OS_OSX
++(nonnull instancetype)colorWithNSColor:(nonnull NSColor *)newNSColor;
+#endif
+
 /// @}
 
 /// @name Initialization
@@ -31,6 +40,10 @@
 -(nonnull instancetype)initWithCGColor:(nonnull CGColorRef)cgColor NS_DESIGNATED_INITIALIZER;
 -(nonnull instancetype)initWithComponentRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
 -(nullable instancetype)initWithCoder:(nonnull NSCoder *)decoder NS_DESIGNATED_INITIALIZER;
+
+#if TARGET_OS_OSX
+-(nonnull instancetype)initWithNSColor:(nonnull NSColor *)newNSColor NS_DESIGNATED_INITIALIZER;
+#endif
 
 -(nonnull instancetype)colorWithAlphaComponent:(CGFloat)alpha;
 /// @}

--- a/framework/Source/CPTColorTests.m
+++ b/framework/Source/CPTColorTests.m
@@ -16,6 +16,8 @@
     XCTAssertEqualObjects(color, newColor, @"Colors not equal");
     
 #if TARGET_OS_OSX
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
     // Workaround since @available macro is not there
     if ( [NSColor respondsToSelector:@selector(colorNamed:)] ) {
 
@@ -26,6 +28,7 @@
         XCTAssertEqualObjects(color, newColor, @"Colors not equal");
         
     }
+#pragma clang diagnostic pop
 #endif
 }
 

--- a/framework/Source/CPTColorTests.m
+++ b/framework/Source/CPTColorTests.m
@@ -14,6 +14,18 @@
     CPTColor *newColor = [self archiveRoundTrip:color];
 
     XCTAssertEqualObjects(color, newColor, @"Colors not equal");
+    
+#if TARGET_OS_OSX
+    if (@available(macOS 10.13, *)) {
+
+        color = [CPTColor colorWithNSColor:[NSColor systemRedColor]];
+        
+        newColor = [self archiveRoundTrip:color];
+        
+        XCTAssertEqualObjects(color, newColor, @"Colors not equal");
+        
+    }
+#endif
 }
 
 @end

--- a/framework/Source/CPTColorTests.m
+++ b/framework/Source/CPTColorTests.m
@@ -16,7 +16,8 @@
     XCTAssertEqualObjects(color, newColor, @"Colors not equal");
     
 #if TARGET_OS_OSX
-    if (@available(macOS 10.13, *)) {
+    // Workaround since @available macro is not there
+    if ( [NSColor respondsToSelector:@selector(colorNamed:)] ) {
 
         color = [CPTColor colorWithNSColor:[NSColor systemRedColor]];
         

--- a/framework/Source/CPTGraph.m
+++ b/framework/Source/CPTGraph.m
@@ -381,7 +381,8 @@ CPTGraphPlotSpaceKey const CPTGraphPlotSpaceNotificationKey       = @"CPTGraphPl
     [self.axisSet.axes makeObjectsPerformSelector:@selector(relabel)];
     
 #if TARGET_OS_OSX
-    if (@available(macOS 10.13, *)) {
+    // Workaround since @available macro is not there
+    if ( [NSColor respondsToSelector:@selector(colorNamed:)] ) {
         NSAppearance *oldAppearance = NSAppearance.currentAppearance;
         NSView *view = (NSView *)self.hostingView;
         NSAppearance.currentAppearance = view.effectiveAppearance;

--- a/framework/Source/CPTGraph.m
+++ b/framework/Source/CPTGraph.m
@@ -381,6 +381,8 @@ CPTGraphPlotSpaceKey const CPTGraphPlotSpaceNotificationKey       = @"CPTGraphPl
     [self.axisSet.axes makeObjectsPerformSelector:@selector(relabel)];
     
 #if TARGET_OS_OSX
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
     // Workaround since @available macro is not there
     if ( [NSColor respondsToSelector:@selector(colorNamed:)] ) {
         NSAppearance *oldAppearance = NSAppearance.currentAppearance;
@@ -391,6 +393,7 @@ CPTGraphPlotSpaceKey const CPTGraphPlotSpaceNotificationKey       = @"CPTGraphPl
     } else {
         [super layoutAndRenderInContext:context];
     }
+#pragma clang diagnostic pop
 #else
     [super layoutAndRenderInContext:context];
 #endif

--- a/framework/Source/CPTGraph.m
+++ b/framework/Source/CPTGraph.m
@@ -379,7 +379,20 @@ CPTGraphPlotSpaceKey const CPTGraphPlotSpaceNotificationKey       = @"CPTGraphPl
 {
     [self reloadDataIfNeeded];
     [self.axisSet.axes makeObjectsPerformSelector:@selector(relabel)];
+    
+#if TARGET_OS_OSX
+    if (@available(macOS 10.13, *)) {
+        NSAppearance *oldAppearance = NSAppearance.currentAppearance;
+        NSView *view = (NSView *)self.hostingView;
+        NSAppearance.currentAppearance = view.effectiveAppearance;
+        [super layoutAndRenderInContext:context];
+        NSAppearance.currentAppearance = oldAppearance;
+    } else {
+        [super layoutAndRenderInContext:context];
+    }
+#else
     [super layoutAndRenderInContext:context];
+#endif
 }
 
 /// @endcond

--- a/framework/Source/CPTLayer.m
+++ b/framework/Source/CPTLayer.m
@@ -323,7 +323,18 @@ CPTLayerNotification const CPTLayerBoundsDidChangeNotification = @"CPTLayerBound
         return;
     }
     else {
+#if TARGET_OS_OSX
+        if (@available(macOS 10.13, *)) {
+            NSAppearance *oldAppearance = NSAppearance.currentAppearance;
+            NSAppearance.currentAppearance = ((NSView *)self.graph.hostingView).effectiveAppearance;
+            [super display];
+            NSAppearance.currentAppearance = oldAppearance;
+        } else {
+            [super display];
+        }
+#else
         [super display];
+#endif
     }
 }
 

--- a/framework/Source/CPTLayer.m
+++ b/framework/Source/CPTLayer.m
@@ -324,7 +324,8 @@ CPTLayerNotification const CPTLayerBoundsDidChangeNotification = @"CPTLayerBound
     }
     else {
 #if TARGET_OS_OSX
-        if (@available(macOS 10.13, *)) {
+        // Workaround since @available macro is not there
+        if ( [NSColor respondsToSelector:@selector(colorNamed:)] ) {
             NSAppearance *oldAppearance = NSAppearance.currentAppearance;
             NSAppearance.currentAppearance = ((NSView *)self.graph.hostingView).effectiveAppearance;
             [super display];

--- a/framework/Source/CPTLayer.m
+++ b/framework/Source/CPTLayer.m
@@ -324,7 +324,10 @@ CPTLayerNotification const CPTLayerBoundsDidChangeNotification = @"CPTLayerBound
     }
     else {
 #if TARGET_OS_OSX
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
         // Workaround since @available macro is not there
+        
         if ( [NSColor respondsToSelector:@selector(colorNamed:)] ) {
             NSAppearance *oldAppearance = NSAppearance.currentAppearance;
             NSAppearance.currentAppearance = ((NSView *)self.graph.hostingView).effectiveAppearance;
@@ -333,6 +336,7 @@ CPTLayerNotification const CPTLayerBoundsDidChangeNotification = @"CPTLayerBound
         } else {
             [super display];
         }
+#pragma clang diagnostic pop
 #else
         [super display];
 #endif


### PR DESCRIPTION
Support creating CPTColor with NSColor and use NSColor for drawing if CPTColor has been created with NSColor. With the additions to CPTGraph and CPTLayer a minimal support for dynamic system colors and colors from the Asset Catalog is given for on screen drawing and printing.

- Only available on macOS
- Changes in CPTGraph and CPTLayer are needed to render dynamic colors properly for different appearances.
- Test for CPTColor has been expanded

A further idea would be to create a theme that automatically adapts to dark mode using system colors.