### PR TITLE
Fixed bug where minor tick labels would remain after axis was removed

### DIFF
--- a/framework/Source/CPTAxis.m
+++ b/framework/Source/CPTAxis.m
@@ -3070,6 +3070,9 @@ NSDecimal CPTNiceLength(NSDecimal length)
             for ( CPTAxisLabel *label in self.axisLabels ) {
                 [label.contentLayer removeFromSuperlayer];
             }
+            for ( CPTAxisLabel *label in self.minorTickAxisLabels ) {
+                [label.contentLayer removeFromSuperlayer];
+            }
             [self.axisTitle.contentLayer removeFromSuperlayer];
         }
     }


### PR DESCRIPTION
Noticed that when removing an axis from a plot, the major tick labels
of that axis would disappear but the minor tick labels would remain
visible.

When you remove an axis from an axis set, `-[CPTAxis setPlotArea:]` gets
called with `nil`. For this case, there was already code present that
would loop over all major tick axis label layers and remove them from
their super layer.  We need to do the same for minor tick label layers
as well.