### PR TITLE
Changes to support dynamic UIColor for dark mode on iOS. Create a CPT…

### DIFF
--- a/framework/Source/CPTColor.h
+++ b/framework/Source/CPTColor.h
@@ -5,6 +5,8 @@
 
 #if TARGET_OS_OSX
 @property (nonatomic, readonly, nonnull) NSColor *nsColor;
+#elif TARGET_OS_SIMULATOR || TARGET_OS_IOS
+@property (nonatomic, readonly, nonnull) UIColor *uiColor;
 #endif
 
 /// @name Factory Methods
@@ -31,6 +33,8 @@
 
 #if TARGET_OS_OSX
 +(nonnull instancetype)colorWithNSColor:(nonnull NSColor *)newNSColor;
+#elif TARGET_OS_SIMULATOR || TARGET_OS_IOS
++(nonnull instancetype)colorWithUIColor:(nonnull UIColor *)newUIColor;
 #endif
 
 /// @}

--- a/framework/Source/CPTGraph.m
+++ b/framework/Source/CPTGraph.m
@@ -396,7 +396,19 @@ CPTGraphPlotSpaceKey const CPTGraphPlotSpaceNotificationKey       = @"CPTGraphPl
     }
 #pragma clang diagnostic pop
 #else
-    [super layoutAndRenderInContext:context];
+    if ( [UITraitCollection instancesRespondToSelector:@selector(performAsCurrentTraitCollection:)] ) {
+        UITraitCollection *traitCollection = ((UIView *)self.hostingView).traitCollection;
+        if ( traitCollection ) {
+            [traitCollection performAsCurrentTraitCollection:^{
+                [super layoutAndRenderInContext:context];
+            }];
+        } else {
+            [super layoutAndRenderInContext:context];
+        }
+    }
+    else {
+        [super layoutAndRenderInContext:context];
+    }
 #endif
 }
 

--- a/framework/Source/CPTLayer.m
+++ b/framework/Source/CPTLayer.m
@@ -339,7 +339,19 @@ CPTLayerNotification const CPTLayerBoundsDidChangeNotification = @"CPTLayerBound
         }
 #pragma clang diagnostic pop
 #else
-        [super display];
+        if ( [UITraitCollection instancesRespondToSelector:@selector(performAsCurrentTraitCollection:)] ) {
+            UITraitCollection *traitCollection = ((UIView *)self.graph.hostingView).traitCollection;
+            if ( traitCollection ) {
+                [traitCollection performAsCurrentTraitCollection:^{
+                    [super display];
+                }];
+            } else {
+                [super display];
+            }
+        }
+        else {
+            [super display];
+        }
 #endif
     }
 }

--- a/framework/iPhoneOnly/CPTPlatformSpecificCategories.m
+++ b/framework/iPhoneOnly/CPTPlatformSpecificCategories.m
@@ -7,16 +7,6 @@
 
 @implementation CPTColor(CPTPlatformSpecificColorExtensions)
 
-/** @property uiColor
- *  @brief Gets the color value as a UIColor.
- **/
-@dynamic uiColor;
-
--(nonnull UIColor *)uiColor
-{
-    return [UIColor colorWithCGColor:self.cgColor];
-}
-
 @end
 
 #pragma mark - CPTLayer


### PR DESCRIPTION
This will add support for dynamic colors based on UIColor. This follows the exact same pattern as it was done last year for macOS