### PR TITLE
Store UIFont/NSFont instance instead of font name+size as advised since iOS13

### DIFF
--- a/framework/MacOnly/CPTTextStylePlatformSpecific.m
+++ b/framework/MacOnly/CPTTextStylePlatformSpecific.m
@@ -40,6 +40,7 @@
     NSFont *styleFont = attributes[NSFontAttributeName];
 
     if ( styleFont ) {
+        newStyle.font = styleFont;
         newStyle.fontName = styleFont.fontName;
         newStyle.fontSize = styleFont.pointSize;
     }
@@ -87,10 +88,10 @@
     CPTMutableDictionary *myAttributes = [NSMutableDictionary dictionary];
 
     // Font
-    NSFont *styleFont  = nil;
+    NSFont *styleFont  = self.font;
     NSString *fontName = self.fontName;
 
-    if ( fontName ) {
+    if ( styleFont == nil && fontName ) {
         styleFont = [NSFont fontWithName:fontName size:self.fontSize];
     }
 
@@ -146,6 +147,7 @@
     NSFont *styleFont = attributes[NSFontAttributeName];
 
     if ( styleFont ) {
+        newStyle.font = styleFont;
         newStyle.fontName = styleFont.fontName;
         newStyle.fontSize = styleFont.pointSize;
     }
@@ -241,10 +243,10 @@
 
     CPTPushCGContext(context);
 
-    NSFont *theFont    = nil;
+    NSFont *theFont    = style.font;
     NSString *fontName = style.fontName;
 
-    if ( fontName ) {
+    if ( theFont == nil && fontName ) {
         theFont = [NSFont fontWithName:fontName size:style.fontSize];
     }
 

--- a/framework/Source/CPTMutableTextStyle.h
+++ b/framework/Source/CPTMutableTextStyle.h
@@ -4,6 +4,11 @@
 
 @interface CPTMutableTextStyle : CPTTextStyle
 
+#if TARGET_OS_SIMULATOR || TARGET_OS_IPHONE || TARGET_OS_TV
+@property (readwrite, strong, nonatomic, nullable) UIFont *font;
+#else
+@property (readwrite, strong, nonatomic, nullable) NSFont *font;
+#endif
 @property (readwrite, copy, nonatomic, nullable) NSString *fontName;
 @property (readwrite, assign, nonatomic) CGFloat fontSize;
 @property (readwrite, copy, nonatomic, nullable) CPTColor *color;

--- a/framework/Source/CPTMutableTextStyle.m
+++ b/framework/Source/CPTMutableTextStyle.m
@@ -7,6 +7,11 @@
 
 @implementation CPTMutableTextStyle
 
+/** @property UIFont* or NSFont* font
+ *  @brief The font. Default is nil
+ **/
+@synthesize font;
+
 /** @property CGFloat fontSize
  *  @brief The font size. Default is @num{12.0}.
  **/

--- a/framework/Source/CPTTextStyle.h
+++ b/framework/Source/CPTTextStyle.h
@@ -16,6 +16,12 @@ typedef NSMutableArray<CPTTextStyle *> CPTMutableTextStyleArray;
 
 @interface CPTTextStyle : NSObject<NSCopying, NSMutableCopying, NSCoding, NSSecureCoding>
 
+// font would override fontName/fontSize if not nil
+#if TARGET_OS_SIMULATOR || TARGET_OS_IPHONE || TARGET_OS_TV
+@property (readonly, strong, nonatomic, nullable) UIFont *font;
+#else
+@property (readonly, strong, nonatomic, nullable) NSFont *font;
+#endif
 @property (readonly, copy, nonatomic, nullable) NSString *fontName;
 @property (readonly, nonatomic) CGFloat fontSize;
 @property (readonly, copy, nonatomic, nullable) CPTColor *color;

--- a/framework/iPhoneOnly/CPTTextStylePlatformSpecific.m
+++ b/framework/iPhoneOnly/CPTTextStylePlatformSpecific.m
@@ -42,6 +42,7 @@
     UIFont *styleFont = attributes[NSFontAttributeName];
 
     if ( styleFont ) {
+        newStyle.font = styleFont;
         newStyle.fontName = styleFont.fontName;
         newStyle.fontSize = styleFont.pointSize;
     }
@@ -72,10 +73,10 @@
     CPTMutableDictionary *myAttributes = [NSMutableDictionary dictionary];
 
     // Font
-    UIFont *styleFont  = nil;
+    UIFont *styleFont  = self.font;
     NSString *fontName = self.fontName;
 
-    if ( fontName ) {
+    if ( styleFont == nil && fontName ) {
         styleFont = [UIFont fontWithName:fontName size:self.fontSize];
     }
 
@@ -132,6 +133,7 @@
     UIFont *styleFont = attributes[NSFontAttributeName];
 
     if ( styleFont ) {
+        newStyle.font = styleFont;
         newStyle.fontName = styleFont.fontName;
         newStyle.fontSize = styleFont.pointSize;
     }
@@ -222,10 +224,10 @@
         UIColor *styleColor = style.attributes[NSForegroundColorAttributeName];
         [styleColor set];
 
-        UIFont *theFont    = nil;
+        UIFont *theFont    = style.font;
         NSString *fontName = style.fontName;
 
-        if ( fontName ) {
+        if (theFont == nil &&  fontName ) {
             theFont = [UIFont fontWithName:fontName size:style.fontSize];
         }
 
@@ -241,7 +243,10 @@
     UIColor *styleColor = style.attributes[NSForegroundColorAttributeName];
     [styleColor set];
 
-    UIFont *theFont = [UIFont fontWithName:style.fontName size:style.fontSize];
+    UIFont *theFont    = self.font;
+    if (theFont == nil) {
+        theFont = [UIFont fontWithName:style.fontName size:style.fontSize];
+    }
 
     [self drawInRect:rect
             withFont:theFont


### PR DESCRIPTION
Please consider the following issues before submitting a pull request:

-[YES] Support all platforms (Mac, iOS, and tvOS)
-[DUNNO] Pass Travis build validation
-[NOPE] Include unit tests where appropriate
-[NOPE] If adding a new feature, consider including a demo in the Plot Gallery example app

Apple now enforces NOT using font name to instantiate a font (rolleye). There are several radars about this everywhere. My own rant here: https://twitter.com/altimac/status/1176788944886915072
Storing the font instance/font descriptor is the new recommended way to use fonts instead.