### PR TITLE
Fixing issue introduced with checkin 9c2edaece9331acaf15a63ff2e564e58…

### DIFF
--- a/framework/Source/CPTGraph.m
+++ b/framework/Source/CPTGraph.m
@@ -397,22 +397,22 @@ CPTGraphPlotSpaceKey const CPTGraphPlotSpaceNotificationKey       = @"CPTGraphPl
 #else
     if ( @available(iOS 13, *)) {
         if ( [UITraitCollection instancesRespondToSelector:@selector(performAsCurrentTraitCollection:)] ) {
-            UITraitCollection *traitCollection = ((UIView *)self.graph.hostingView).traitCollection;
+            UITraitCollection *traitCollection = ((UIView *)self.hostingView).traitCollection;
             if ( traitCollection ) {
                 [traitCollection performAsCurrentTraitCollection: ^{
-                    [super display];
+                    [super layoutAndRenderInContext:context];
                 }];
             }
             else {
-                [super display];
+                [super layoutAndRenderInContext:context];
             }
         }
         else {
-            [super display];
+            [super layoutAndRenderInContext:context];
         }
     }
     else {
-        [super display];
+        [super layoutAndRenderInContext:context];
     }
 #endif
 #pragma clang diagnostic pop


### PR DESCRIPTION
…54267d48. Probably caused by copying and pasting code. Generating an image of the context led to an empty graph.

Hi,

when you added the "if availabe(iOS,13)" check in CPTGraph, you copied too much code from CPTLayer. With your modifications, generating an image out of a layer was not working anymore. This pull request reverts the wrong changes while keeping the availability check.