### PR TITLE
fix Swift macOS sample for DateRange plot

### DIFF
--- a/examples/DatePlot/DatePlot-Bridging-Header.h
+++ b/examples/DatePlot/DatePlot-Bridging-Header.h
@@ -1,1 +1,0 @@
-#import <CorePlot/CorePlot.h>

--- a/examples/DatePlot/DatePlot.xcodeproj/project.pbxproj
+++ b/examples/DatePlot/DatePlot.xcodeproj/project.pbxproj
@@ -111,7 +111,6 @@
 		C33E19A7198330CA00182AF2 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Source/AppDelegate.swift; sourceTree = "<group>"; };
 		C37A409820E030B500C4FF48 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Base; path = Base.lproj/Info.plist; sourceTree = "<group>"; };
 		C385066522A9CC740086BAD5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		C3A1443E197DE35F0048F1FF /* DatePlot-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DatePlot-Bridging-Header.h"; sourceTree = "<group>"; };
 		C3A1443F197DE35F0048F1FF /* DateController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DateController.swift; path = Source/DateController.swift; sourceTree = "<group>"; };
 		C3C3CBBF19EA07F600A0296A /* CorePlotWarnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = CorePlotWarnings.xcconfig; path = ../../framework/xcconfig/CorePlotWarnings.xcconfig; sourceTree = "<group>"; };
 		C3D0A1B620E0184100BA2921 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/DatePlot.xib; sourceTree = "<group>"; };
@@ -150,7 +149,6 @@
 		080E96DDFE201D6D7F000001 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				C3A1443E197DE35F0048F1FF /* DatePlot-Bridging-Header.h */,
 				C33E19A7198330CA00182AF2 /* AppDelegate.swift */,
 				C3A1443F197DE35F0048F1FF /* DateController.swift */,
 			);
@@ -437,7 +435,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.CorePlot.${PRODUCT_NAME:identifier}";
 				PRODUCT_NAME = DatePlot;
-				SWIFT_OBJC_BRIDGING_HEADER = "DatePlot-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -463,7 +460,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.CorePlot.${PRODUCT_NAME:identifier}";
 				PRODUCT_NAME = DatePlot;
-				SWIFT_OBJC_BRIDGING_HEADER = "DatePlot-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 			};

--- a/examples/DatePlot/Source/DateController.swift
+++ b/examples/DatePlot/Source/DateController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Cocoa
+import CorePlot
 
 class DateController : NSObject, CPTPlotDataSource {
     private let oneDay : Double = 24 * 60 * 60;

--- a/examples/DatePlot/Source/DateController.swift
+++ b/examples/DatePlot/Source/DateController.swift
@@ -73,8 +73,6 @@ class DateController : NSObject, CPTPlotDataSource {
         newGraph.add(dataSourceLinePlot)
 
         self.graph = newGraph
-
-        newGraph.reloadData()
     }
 
     func newPlotData() -> [Double]

--- a/examples/DatePlot/Source/DateController.swift
+++ b/examples/DatePlot/Source/DateController.swift
@@ -73,6 +73,8 @@ class DateController : NSObject, CPTPlotDataSource {
         newGraph.add(dataSourceLinePlot)
 
         self.graph = newGraph
+
+        newGraph.reloadData()
     }
 
     func newPlotData() -> [Double]


### PR DESCRIPTION
The window was empty before I added the call to `reloadData()`. I also took the liberty to remove the bridging header from the Swift project to not make it a mixed-language project for no reason. Just in case Swift newcomers are looking and wonder (1) where the missing import is taking place, and (2) deduce that this is considered best practice.