### PR TITLE
Initial implementation of skewed X axis

### DIFF
--- a/examples/CorePlotGallery/Plot Gallery-Mac/PlotViewItem.xib
+++ b/examples/CorePlotGallery/Plot Gallery-Mac/PlotViewItem.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/framework/Source/CPTAxis.m
+++ b/framework/Source/CPTAxis.m
@@ -1034,6 +1034,10 @@ NSDecimal CPTNiceLength(NSDecimal length);
         case CPTScaleTypeLinear:
             // supported scale type
             break;
+            
+        case CPTScaleTypeSkew:
+            // supported scale type
+            break;
 
         case CPTScaleTypeLog:
             // supported scale type--check range
@@ -1066,6 +1070,7 @@ NSDecimal CPTNiceLength(NSDecimal length);
     // Filter troublesome values and return empty sets
     if ((length != 0.0) && !isinf(length)) {
         switch ( scaleType ) {
+            case CPTScaleTypeSkew:
             case CPTScaleTypeLinear:
             {
                 // Determine interval value

--- a/framework/Source/CPTDefinitions.h
+++ b/framework/Source/CPTDefinitions.h
@@ -167,6 +167,7 @@ typedef NS_ENUM (NSInteger, CPTErrorBarType) {
  **/
 typedef NS_ENUM (NSInteger, CPTScaleType) {
     CPTScaleTypeLinear,    ///< Linear axis scale
+    CPTScaleTypeSkew,      ///< Linear axis scale that is skewed relative to orthogonal coordinate
     CPTScaleTypeLog,       ///< Logarithmic axis scale
     CPTScaleTypeAngular,   ///< Angular axis scale (not implemented)
     CPTScaleTypeDateTime,  ///< Date/time axis scale (not implemented)

--- a/framework/Source/CPTPlot.m
+++ b/framework/Source/CPTPlot.m
@@ -986,6 +986,7 @@ CPTPlotBinding const CPTPlotBindingDataLabels = @"dataLabels"; ///< Plot data la
     if ( numbers ) {
         switch ( [thePlotSpace scaleTypeForCoordinate:coordinate] ) {
             case CPTScaleTypeLinear:
+            case CPTScaleTypeSkew:
             case CPTScaleTypeLog:
             case CPTScaleTypeLogModulus:
             {
@@ -1082,6 +1083,7 @@ CPTPlotBinding const CPTPlotBindingDataLabels = @"dataLabels"; ///< Plot data la
 
         switch ( [thePlotSpace scaleTypeForCoordinate:coordinate] ) {
             case CPTScaleTypeLinear:
+            case CPTScaleTypeSkew:
             case CPTScaleTypeLog:
             case CPTScaleTypeLogModulus:
             {

--- a/framework/Source/CPTXYAxis.m
+++ b/framework/Source/CPTXYAxis.m
@@ -817,6 +817,7 @@
         CPTScaleType scaleType = [thePlotSpace scaleTypeForCoordinate:theCoordinate];
 
         switch ( scaleType ) {
+            case CPTScaleTypeSkew:
             case CPTScaleTypeLinear:
                 location = axisRange.midPoint;
                 break;

--- a/framework/Source/CPTXYPlotSpace.h
+++ b/framework/Source/CPTXYPlotSpace.h
@@ -10,6 +10,7 @@
 @property (nonatomic, readwrite, copy, nonnull) CPTPlotRange *yRange;
 @property (nonatomic, readwrite, copy, nullable) CPTPlotRange *globalXRange;
 @property (nonatomic, readwrite, copy, nullable) CPTPlotRange *globalYRange;
+@property (nonatomic, readwrite) double skewAngle;
 @property (nonatomic, readwrite, assign) CPTScaleType xScaleType;
 @property (nonatomic, readwrite, assign) CPTScaleType yScaleType;
 

--- a/framework/Source/CPTXYPlotSpace.m
+++ b/framework/Source/CPTXYPlotSpace.m
@@ -113,6 +113,11 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c);
  **/
 @synthesize globalYRange;
 
+/** @property double skewAngle
+ *  @brief If using CPTScaleTypeSkew, what angle (in degrees) to skew by
+ */
+@synthesize skewAngle;
+
 /** @property CPTScaleType xScaleType
  *  @brief The scale type of the x coordinate. Defaults to #CPTScaleTypeLinear.
  **/
@@ -183,6 +188,7 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c);
  *  - @ref yRange = [@num{0}, @num{1}]
  *  - @ref globalXRange = @nil
  *  - @ref globalYRange = @nil
+ *  - @ref skewAngle = @num{45.0}
  *  - @ref xScaleType = #CPTScaleTypeLinear
  *  - @ref yScaleType = #CPTScaleTypeLinear
  *  - @ref allowsMomentum = @NO
@@ -203,6 +209,7 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c);
         yRange           = [[CPTPlotRange alloc] initWithLocation:@0.0 length:@1.0];
         globalXRange     = nil;
         globalYRange     = nil;
+        skewAngle        = 45.0;
         xScaleType       = CPTScaleTypeLinear;
         yScaleType       = CPTScaleTypeLinear;
         lastDragPoint    = CGPointZero;
@@ -246,6 +253,7 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c);
     [coder encodeCGFloat:self.momentumAcceleration forKey:@"CPTXYPlotSpace.momentumAcceleration"];
     [coder encodeCGFloat:self.bounceAcceleration forKey:@"CPTXYPlotSpace.bounceAcceleration"];
     [coder encodeCGFloat:self.minimumDisplacementToDrag forKey:@"CPTXYPlotSpace.minimumDisplacementToDrag"];
+    [coder encodeDouble:self.skewAngle forKey:@"CPTXYPlotSpace.skewAngle"];
 
     // No need to archive these properties:
     // lastDragPoint
@@ -274,6 +282,7 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c);
                                             forKey:@"CPTXYPlotSpace.globalYRange"] copy];
         xScaleType = (CPTScaleType)[coder decodeIntegerForKey:@"CPTXYPlotSpace.xScaleType"];
         yScaleType = (CPTScaleType)[coder decodeIntegerForKey:@"CPTXYPlotSpace.yScaleType"];
+        skewAngle = [coder decodeDoubleForKey:@"CPTXYPlotSpace.skewAngle"];
 
         if ( [coder containsValueForKey:@"CPTXYPlotSpace.allowsMomentum"] ) {
             self.allowsMomentum = [coder decodeBoolForKey:@"CPTXYPlotSpace.allowsMomentum"];
@@ -1035,7 +1044,35 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
         case CPTScaleTypeCategory:
             viewPoint.x = [self viewCoordinateForViewLength:plotArea.widthDecimal linearPlotRange:self.xRange plotCoordinateValue:plotPoint[CPTCoordinateX].decimalValue];
             break;
-
+            
+        case CPTScaleTypeSkew:
+        {
+            // Relate the plot space width to the height by the
+            // skewAngle we are going to transform by.
+            double dx = layerSize.width;
+            double dy = tan(self.skewAngle * M_PI / 180.0) * dx;
+            
+            // We need to know our Y coordinate to compute
+            // how much the horizontal offset is to skew the data point.
+            double y;
+            switch (self.yScaleType) {
+                // If the Y coordinate is in linear space
+                case CPTScaleTypeLinear:
+                    y = [self viewCoordinateForViewLength:plotArea.heightDecimal linearPlotRange:self.yRange plotCoordinateValue:plotPoint[CPTCoordinateY].decimalValue];
+                    break;
+                // If the Y coordinate is in log space
+                case CPTScaleTypeLog:
+                    y = [self viewCoordinateForViewLength:layerSize.height logPlotRange:self.yRange doublePrecisionPlotCoordinateValue:plotPoint[CPTCoordinateY].doubleValue];
+                    break;
+                default:
+                    [NSException raise:CPTException format:@" Y Scale type not supported in CPTXYPlotSpace when using CPTScaleTYpeSkew for X Scale"];
+            }
+            // get un-transformed view coordinate for our X point
+            double x = [self viewCoordinateForViewLength:plotArea.widthDecimal linearPlotRange:self.xRange plotCoordinateValue:plotPoint[CPTCoordinateX].decimalValue];
+            // transform the point in view coordinate space
+            viewPoint.x = x + ((y) / dy) * (dx);
+            break;
+        }
         case CPTScaleTypeLog:
         {
             viewPoint.x = [self viewCoordinateForViewLength:layerSize.width logPlotRange:self.xRange doublePrecisionPlotCoordinateValue:plotPoint[CPTCoordinateX].doubleValue];
@@ -1057,7 +1094,10 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
         case CPTScaleTypeCategory:
             viewPoint.y = [self viewCoordinateForViewLength:plotArea.heightDecimal linearPlotRange:self.yRange plotCoordinateValue:plotPoint[CPTCoordinateY].decimalValue];
             break;
-
+        case CPTScaleTypeSkew:
+        {
+            [NSException raise:CPTException format:@" Y Scale type currently not supported in CPTXYPlotSpace"];
+        }
         case CPTScaleTypeLog:
         {
             viewPoint.y = [self viewCoordinateForViewLength:layerSize.height logPlotRange:self.yRange doublePrecisionPlotCoordinateValue:plotPoint[CPTCoordinateY].doubleValue];
@@ -1097,7 +1137,35 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
         case CPTScaleTypeCategory:
             viewPoint.x = [self viewCoordinateForViewLength:plotArea.widthDecimal linearPlotRange:self.xRange plotCoordinateValue:plotPoint[CPTCoordinateX]];
             break;
-
+            
+        case CPTScaleTypeSkew:
+        {
+            // Relate the plot space width to the height by the
+            // skewAngle we are going to transform by.
+            double dx = layerSize.width;
+            double dy = tan(self.skewAngle * M_PI / 180.0) * dx;
+            
+            // We need to know our Y coordinate to compute
+            // how much the horizontal offset is to skew the data point.
+            double y = CPTDecimalDoubleValue(plotPoint[CPTCoordinateY]);
+            switch (self.yScaleType) {
+                // If the Y coordinate is in linear space
+                case CPTScaleTypeLinear:
+                    y = [self viewCoordinateForViewLength:plotArea.heightDecimal linearPlotRange:self.yRange plotCoordinateValue:plotPoint[CPTCoordinateY]];
+                    break;
+                // If the Y coordinate is in log space
+                case CPTScaleTypeLog:
+                    y = [self viewCoordinateForViewLength:layerSize.height logPlotRange:self.yRange doublePrecisionPlotCoordinateValue:y];
+                    break;
+                default:
+                    [NSException raise:CPTException format:@" Y Scale type not supported in CPTXYPlotSpace when using CPTScaleTYpeSkew for X Scale"];
+            }
+            // get un-transformed view coordinate for our X point
+            double x = [self viewCoordinateForViewLength:plotArea.widthDecimal linearPlotRange:self.xRange plotCoordinateValue:plotPoint[CPTCoordinateX]];
+            // transform the point in view coordinate space
+            viewPoint.x = x + ((y) / dy) * (dx);
+            break;
+        }
         case CPTScaleTypeLog:
         {
             double x = CPTDecimalDoubleValue(plotPoint[CPTCoordinateX]);
@@ -1122,6 +1190,11 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
             viewPoint.y = [self viewCoordinateForViewLength:plotArea.heightDecimal linearPlotRange:self.yRange plotCoordinateValue:plotPoint[CPTCoordinateY]];
             break;
 
+        case CPTScaleTypeSkew:
+        {
+            [NSException raise:CPTException format:@" Y Scale type currently not supported in CPTXYPlotSpace"];
+            break;
+        }
         case CPTScaleTypeLog:
         {
             double y = CPTDecimalDoubleValue(plotPoint[CPTCoordinateY]);
@@ -1163,7 +1236,34 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
         case CPTScaleTypeCategory:
             viewPoint.x = [self viewCoordinateForViewLength:layerSize.width linearPlotRange:self.xRange doublePrecisionPlotCoordinateValue:plotPoint[CPTCoordinateX]];
             break;
-
+        case CPTScaleTypeSkew:
+        {
+            // Relate the plot space width to the height by the
+            // skewAngle we are going to transform by.
+            double dx = layerSize.width;
+            double dy = tan(self.skewAngle * M_PI / 180.0) * dx;
+            
+            // We need to know our Y coordinate to compute
+            // how much the horizontal offset is to skew the data point.
+            double y;
+            switch (self.yScaleType) {
+                // If the Y coordinate is in linear space
+                case CPTScaleTypeLinear:
+                    y = [self viewCoordinateForViewLength:layerSize.height linearPlotRange:self.yRange doublePrecisionPlotCoordinateValue:plotPoint[CPTCoordinateY]];
+                    break;
+                // If the Y coordinate is in log space
+                case CPTScaleTypeLog:
+                    y =  [self viewCoordinateForViewLength:layerSize.height logPlotRange:self.yRange doublePrecisionPlotCoordinateValue:plotPoint[CPTCoordinateY]];
+                    break;
+                default:
+                    [NSException raise:CPTException format:@" Y Scale type not supported in CPTXYPlotSpace when using CPTScaleTYpeSkew for X Scale"];
+            }
+            // get un-transformed view coordinate for our X point
+            double x = [self viewCoordinateForViewLength:layerSize.width linearPlotRange:self.xRange doublePrecisionPlotCoordinateValue:plotPoint[CPTCoordinateX]];
+            // transform the point in view coordinate space
+            viewPoint.x = x + ((y) / dy) * (dx);
+            break;
+        }
         case CPTScaleTypeLog:
             viewPoint.x = [self viewCoordinateForViewLength:layerSize.width logPlotRange:self.xRange doublePrecisionPlotCoordinateValue:plotPoint[CPTCoordinateX]];
             break;
@@ -1181,7 +1281,11 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
         case CPTScaleTypeCategory:
             viewPoint.y = [self viewCoordinateForViewLength:layerSize.height linearPlotRange:self.yRange doublePrecisionPlotCoordinateValue:plotPoint[CPTCoordinateY]];
             break;
-
+        case CPTScaleTypeSkew:
+        {
+            [NSException raise:CPTException format:@" Y Scale type currently not supported in CPTXYPlotSpace"];
+            break;
+        }
         case CPTScaleTypeLog:
             viewPoint.y = [self viewCoordinateForViewLength:layerSize.height logPlotRange:self.yRange doublePrecisionPlotCoordinateValue:plotPoint[CPTCoordinateY]];
             break;
@@ -1220,11 +1324,21 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
     switch ( self.xScaleType ) {
         case CPTScaleTypeLinear:
         case CPTScaleTypeCategory:
-            plotPoint[CPTCoordinateX] = [NSDecimalNumber decimalNumberWithDecimal:[self plotCoordinateForViewLength:CPTDecimalFromCGFloat(point.x)
-                                                                                                    linearPlotRange:self.xRange
-                                                                                                       boundsLength:plotArea.widthDecimal]];
+            plotPoint[CPTCoordinateX] = [NSDecimalNumber decimalNumberWithDecimal:[self plotCoordinateForViewLength:CPTDecimalFromCGFloat(point.x) linearPlotRange:self.xRange boundsLength:plotArea.widthDecimal]];
             break;
-
+            
+        case CPTScaleTypeSkew:
+        {
+            double dx = boundsSize.width;
+            double dy = tan(self.skewAngle * M_PI / 180.0) * dx;
+            double y = point.y;
+            
+            point.x -= ((y) / dy) * (dx);
+            
+            plotPoint[CPTCoordinateX] = [NSDecimalNumber decimalNumberWithDecimal:[self plotCoordinateForViewLength:CPTDecimalFromCGFloat(point.x)
+                linearPlotRange:self.xRange boundsLength:plotArea.widthDecimal]];
+            break;
+        }
         case CPTScaleTypeLog:
             plotPoint[CPTCoordinateX] = @([self doublePrecisionPlotCoordinateForViewLength:point.x logPlotRange:self.xRange boundsLength:boundsSize.width]);
             break;
@@ -1240,11 +1354,13 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
     switch ( self.yScaleType ) {
         case CPTScaleTypeLinear:
         case CPTScaleTypeCategory:
-            plotPoint[CPTCoordinateY] = [NSDecimalNumber decimalNumberWithDecimal:[self plotCoordinateForViewLength:CPTDecimalFromCGFloat(point.y)
-                                                                                                    linearPlotRange:self.yRange
-                                                                                                       boundsLength:plotArea.heightDecimal]];
+            plotPoint[CPTCoordinateY] = [NSDecimalNumber decimalNumberWithDecimal:[self plotCoordinateForViewLength:CPTDecimalFromCGFloat(point.y) linearPlotRange:self.yRange boundsLength:plotArea.heightDecimal]];
             break;
-
+        case CPTScaleTypeSkew:
+        {
+            [NSException raise:CPTException format:@" Y Scale type currently not supported in CPTXYPlotSpace"];
+            break;
+        }
         case CPTScaleTypeLog:
             plotPoint[CPTCoordinateY] = @([self doublePrecisionPlotCoordinateForViewLength:point.y logPlotRange:self.yRange boundsLength:boundsSize.height]);
             break;
@@ -1283,7 +1399,16 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
         case CPTScaleTypeCategory:
             plotPoint[CPTCoordinateX] = [self plotCoordinateForViewLength:CPTDecimalFromCGFloat(point.x) linearPlotRange:self.xRange boundsLength:plotArea.widthDecimal];
             break;
-
+        case CPTScaleTypeSkew:
+        {
+            double dx = boundsSize.width;
+            double dy = tan(self.skewAngle * M_PI / 180.0) * dx;
+            double y = point.y;
+            
+            point.x -= ((y) / dy) * (dx);
+            plotPoint[CPTCoordinateX] = [self plotCoordinateForViewLength:CPTDecimalFromCGFloat(point.x) linearPlotRange:self.xRange boundsLength:plotArea.widthDecimal];
+            break;
+        }
         case CPTScaleTypeLog:
             plotPoint[CPTCoordinateX] = CPTDecimalFromDouble([self doublePrecisionPlotCoordinateForViewLength:point.x logPlotRange:self.xRange boundsLength:boundsSize.width]);
             break;
@@ -1301,7 +1426,11 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
         case CPTScaleTypeCategory:
             plotPoint[CPTCoordinateY] = [self plotCoordinateForViewLength:CPTDecimalFromCGFloat(point.y) linearPlotRange:self.yRange boundsLength:plotArea.heightDecimal];
             break;
-
+        case CPTScaleTypeSkew:
+        {
+            [NSException raise:CPTException format:@" Y Scale type currently not supported in CPTXYPlotSpace"];
+            break;
+        }
         case CPTScaleTypeLog:
             plotPoint[CPTCoordinateY] = CPTDecimalFromDouble([self doublePrecisionPlotCoordinateForViewLength:point.y logPlotRange:self.yRange boundsLength:boundsSize.height]);
             break;
@@ -1337,7 +1466,17 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
         case CPTScaleTypeCategory:
             plotPoint[CPTCoordinateX] = [self doublePrecisionPlotCoordinateForViewLength:point.x linearPlotRange:self.xRange boundsLength:boundsSize.width];
             break;
+        case CPTScaleTypeSkew:
+        {
+            double dx = boundsSize.width;
+            double dy = tan(self.skewAngle * M_PI / 180.0) * dx;
+            double y = point.y;
+            
+            point.x -= ((y) / dy) * (dx);
 
+            plotPoint[CPTCoordinateX] = [self doublePrecisionPlotCoordinateForViewLength:point.x linearPlotRange:self.xRange boundsLength:boundsSize.width];
+            break;
+        }
         case CPTScaleTypeLog:
             plotPoint[CPTCoordinateX] = [self doublePrecisionPlotCoordinateForViewLength:point.x logPlotRange:self.xRange boundsLength:boundsSize.width];
             break;
@@ -1355,7 +1494,11 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
         case CPTScaleTypeCategory:
             plotPoint[CPTCoordinateY] = [self doublePrecisionPlotCoordinateForViewLength:point.y linearPlotRange:self.yRange boundsLength:boundsSize.height];
             break;
-
+        case CPTScaleTypeSkew:
+        {
+            [NSException raise:CPTException format:@" Y Scale type currently not supported in CPTXYPlotSpace"];
+            break;
+        }
         case CPTScaleTypeLog:
             plotPoint[CPTCoordinateY] = [self doublePrecisionPlotCoordinateForViewLength:point.y logPlotRange:self.yRange boundsLength:boundsSize.height];
             break;
@@ -1927,7 +2070,11 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
         case CPTScaleTypeLinear:
             xScaleTypeDesc = @"CPTScaleTypeLinear";
             break;
-
+            
+        case CPTScaleTypeSkew:
+            xScaleTypeDesc = @"CPTScaleTypeSkew";
+            break;
+            
         case CPTScaleTypeLog:
             xScaleTypeDesc = @"CPTScaleTypeLog";
             break;
@@ -1961,6 +2108,9 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c)
         case CPTScaleTypeLinear:
             yScaleTypeDesc = @"CPTScaleTypeLinear";
             break;
+            
+        case CPTScaleTypeSkew:
+            yScaleTypeDesc = @"CPTScaleTypeSkew";
 
         case CPTScaleTypeLog:
             yScaleTypeDesc = @"CPTScaleTypeLog";


### PR DESCRIPTION
This is an initial attempt at a pull request to add the capability for skewed X-axis lines on an X-Y plot. It currently supports a skewed X axis for both linear and logarithmic Y axis types. 

I use the words "initial" for a few reasons, one being that I'm relatively new to iOS development and Xcode and I'm not entirely sure about how and where to add appropriate tests for this new feature. Another reason for the word "initial" is that this can and should be extended to skewed Y axes as well, but I want to hold off until there's approval on the method of implementation in ```CPTXYPlotSpace```. If a different implementation style is requested, then the functionality can be extended to the Y axis range. Finally, it's "initial" because the behavior of axis grid lines in this context is not super well defined. See #454 for questions/discussion on that. I'd like to be able to implement some good default behavior here, but so far my efforts have not been fruitful.  

Looking forward to the review and suggestions.