### PR TITLE
Fixed constrainRange to properly account for ranges with negative lengths. 

### DIFF
--- a/framework/Source/CPTXYPlotSpace.m
+++ b/framework/Source/CPTXYPlotSpace.m
@@ -531,15 +531,29 @@ CGFloat CPTFirstPositiveRoot(CGFloat a, CGFloat b, CGFloat c);
 
     CPTPlotRange *theGlobalRange = globalRange;
 
-    if ( CPTDecimalGreaterThanOrEqualTo(existingRange.lengthDecimal, theGlobalRange.lengthDecimal)) {
-        return [theGlobalRange copy];
+    if (CPTDecimalGreaterThanOrEqualTo(existingRange.lengthDecimal, CPTDecimalFromInteger(0))) {
+        if ( CPTDecimalGreaterThanOrEqualTo(existingRange.lengthDecimal, theGlobalRange.lengthDecimal)) {
+            return [theGlobalRange copy];
+        }
+        else {
+            CPTMutablePlotRange *newRange = [existingRange mutableCopy];
+            [newRange shiftEndToFitInRange:theGlobalRange];
+            [newRange shiftLocationToFitInRange:theGlobalRange];
+            return newRange;
+        }
     }
     else {
-        CPTMutablePlotRange *newRange = [existingRange mutableCopy];
-        [newRange shiftEndToFitInRange:theGlobalRange];
-        [newRange shiftLocationToFitInRange:theGlobalRange];
-        return newRange;
+        if ( CPTDecimalLessThanOrEqualTo(existingRange.lengthDecimal, theGlobalRange.lengthDecimal)) {
+            return [theGlobalRange copy];
+        }
+        else {
+            CPTMutablePlotRange *newRange = [existingRange mutableCopy];
+            [newRange shiftEndToFitInRange:theGlobalRange];
+            [newRange shiftLocationToFitInRange:theGlobalRange];
+            return newRange;
+        }
     }
+
 }
 
 -(void)animateRangeForCoordinate:(CPTCoordinate)coordinate shift:(NSDecimal)shift momentumTime:(CGFloat)momentumTime speed:(CGFloat)speed acceleration:(CGFloat)acceleration


### PR DESCRIPTION
When working with ranges that have negative lengths (for example, an X-Y plot with an inverted Y axis scale) and using pinch-zoom interaction, the interaction will break the ```globalXRange``` and ```globalYRange``` restrictions because it only checks for positive range lengths. This is especially problematic for log plot ranges that could eventually cross the 0 value, as log10(0) causes programs to crash. 

These changes check the sign of the length range and then return the appropriate constraints based on that. I have tested and confirmed that with this change, pinch-zoom scaling in logarithmic space with an inverted axis no longer causes crashes. 