### PR TITLE
Changed +load to +initialize, per XCode 14.

### DIFF
--- a/framework/Source/_CPTDarkGradientTheme.m
+++ b/framework/Source/_CPTDarkGradientTheme.m
@@ -21,7 +21,7 @@ CPTThemeName const kCPTDarkGradientTheme = @"Dark Gradients";
  **/
 @implementation _CPTDarkGradientTheme
 
-+(void)load
++(void)initialize
 {
     [self registerTheme:self];
 }

--- a/framework/Source/_CPTPlainBlackTheme.m
+++ b/framework/Source/_CPTPlainBlackTheme.m
@@ -18,7 +18,7 @@ CPTThemeName const kCPTPlainBlackTheme = @"Plain Black";
  **/
 @implementation _CPTPlainBlackTheme
 
-+(void)load
++(void)initialize
 {
     [self registerTheme:self];
 }

--- a/framework/Source/_CPTPlainWhiteTheme.m
+++ b/framework/Source/_CPTPlainWhiteTheme.m
@@ -18,7 +18,7 @@ CPTThemeName const kCPTPlainWhiteTheme = @"Plain White";
  **/
 @implementation _CPTPlainWhiteTheme
 
-+(void)load
++(void)initialize
 {
     [self registerTheme:self];
 }

--- a/framework/Source/_CPTSlateTheme.m
+++ b/framework/Source/_CPTSlateTheme.m
@@ -21,7 +21,7 @@ CPTThemeName const kCPTSlateTheme = @"Slate";
  **/
 @implementation _CPTSlateTheme
 
-+(void)load
++(void)initialize
 {
     [self registerTheme:self];
 }

--- a/framework/Source/_CPTStocksTheme.m
+++ b/framework/Source/_CPTStocksTheme.m
@@ -19,7 +19,7 @@ CPTThemeName const kCPTStocksTheme = @"Stocks";
  **/
 @implementation _CPTStocksTheme
 
-+(void)load
++(void)initialize
 {
     [self registerTheme:self];
 }


### PR DESCRIPTION
XCode 14 gives an error when using `+load` instead of `+initialize`. Seems like it should just be a warning and not an error, but that's just my opinion. Changing it didn't seem to hurt anything, so here's a pull request if anyone wants to use it.