### PR TITLE
Influence Carthage Xcode project lookup

### DIFF
--- a/Carthage/CorePlotCarthage.xcworkspace/contents.xcworkspacedata
+++ b/Carthage/CorePlotCarthage.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:../framework/CorePlot.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Carthage/CorePlotCarthage.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Carthage/CorePlotCarthage.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Carthage just uses any Xcode project or workspace file it can find to build frameworks. This is an attempt to tell Carthage where to start. 

Workspaces have higher precedence than projects, so I added a new Workspace with a reference to the framework project instead of merely a symlink.

Was an attempt to influence #468 but doesn't actually help (other projects are still traversed by Carthage and then fail). With the DatePlot project deleted to prevent the exception, Carthage would start to build the framework from the CorePlotExamples workspace, which sounds a bit odd, so this PR merely affects that lookup. -- Feel free to discard/close without merging this if that doesn't add enough value.