### PR TITLE
Lower macOS deployment target in Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "CorePlot",
     platforms: [
-              .macOS(.v10_14),
+              .macOS(.v10_13),
               .iOS(.v12),
               .tvOS(.v12)
           ],


### PR DESCRIPTION
I noticed that CorePlot requires 10.14 -- which is unfortunate for the app I was using the release-2.4 branch in :)

The Cocoapods version is still the most backwards-compatible (10.9!) of all. So I checked if things wouldn't compile with a lower target, but it works fine, actually.

----
By the way:  I tested to lower the target to 10.13 in a couple of the example projects as well and that seems to work fine, too.