### PR TITLE
Fix rendering without hosting view on macOS

### DIFF
--- a/framework/Source/CPTLayer.m
+++ b/framework/Source/CPTLayer.m
@@ -330,22 +330,28 @@ CPTLayerNotification const CPTLayerBoundsDidChangeNotification = @"CPTLayerBound
 
         if ( [NSView instancesRespondToSelector:@selector(effectiveAppearance)] ) {
             CPTGraphHostingView *hostingView = [self findHostingView];
-            if ( [NSAppearance instancesRespondToSelector:@selector(performAsCurrentDrawingAppearance:)] ) {
+            NSAppearance *appearance = hostingView.effectiveAppearance;
+
+            if ( appearance && [NSAppearance instancesRespondToSelector:@selector(performAsCurrentDrawingAppearance:)] ) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
-                [hostingView.effectiveAppearance performAsCurrentDrawingAppearance: ^{
+                [appearance performAsCurrentDrawingAppearance: ^{
                     [super display];
                 }];
 #pragma clang diagnostic pop
             }
-            else {
+            else if ( appearance ) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 NSAppearance *oldAppearance = NSAppearance.currentAppearance;
-                NSAppearance.currentAppearance = hostingView.effectiveAppearance;
+                NSAppearance.currentAppearance = appearance;
                 [super display];
                 NSAppearance.currentAppearance = oldAppearance;
 #pragma clang diagnostic pop
+            }
+            else {
+                // No hosting view; fall back to the default rendering path so the layer still draws.
+                [super display];
             }
         }
         else {


### PR DESCRIPTION
Problem: On macOS the Core Plot layers were blank when attached directly as sublayers (no hosting view). The mac-only drawing path bailed because effectiveAppearance was nil, so [super display] never ran.

Fix: In `CPTLayer.display`, still respect effectiveAppearance when it exists, but fall back to the normal display path if there’s no hosting view/appearance.

